### PR TITLE
Use correct julia<->llvm pointer conversion convention, support Julia 1.9

### DIFF
--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -44,10 +44,10 @@
 
         define i8* @main(i64 %jlname, i64 %jlmode) {
         entry:
-            %name = inttoptr i64 %jlname to i8*
-            %mode = inttoptr i64 %jlmode to i8*
-            %fp = call i8* (i8*, i8*) @fopen(i8* %name, i8* %mode)
-            ret i8* %fp
+          %name = inttoptr i64 %jlname to i8*
+          %mode = inttoptr i64 %jlmode to i8*
+          %fp = call i8* (i8*, i8*) @fopen(i8* %name, i8* %mode)
+          ret i8* %fp
         }
         """, "main"), Ptr{FILE}, Tuple{Ptr{UInt8}, Ptr{UInt8}}, name, mode)
     end
@@ -85,8 +85,8 @@
 
         define i32 @main(i8* %fp) {
         entry:
-            %status = call i32 (i8*) @fclose(i8* %fp)
-            ret i32 %status
+          %status = call i32 (i8*) @fclose(i8* %fp)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}}, fp)
     end
@@ -142,8 +142,8 @@
 
         define i32 @main(i8* %fp, i64 %offset, i32 %whence) {
         entry:
-            %status = call i32 @fseek(i8* %fp, i64 %offset, i32 %whence)
-            ret i32 %status
+          %status = call i32 @fseek(i8* %fp, i64 %offset, i32 %whence)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Int64, Int32}, fp, offset, whence)
     end
@@ -179,8 +179,8 @@
 
         define i8* @main() {
         entry:
-            %ptr = load i8*, i8** @__stdoutp, align 8
-            ret i8* %ptr
+          %ptr = load i8*, i8** @__stdoutp, align 8
+          ret i8* %ptr
         }
         """, "main"), Ptr{FILE}, Tuple{})
     end
@@ -191,8 +191,8 @@ else
 
         define i8* @main() {
         entry:
-            %ptr = load i8*, i8** @stdout, align 8
-            ret i8* %ptr
+          %ptr = load i8*, i8** @stdout, align 8
+          ret i8* %ptr
         }
         """, "main"), Ptr{FILE}, Tuple{})
     end
@@ -224,8 +224,8 @@ end
 
         define i8* @main() {
         entry:
-            %ptr = load i8*, i8** @__stderrp, align 8
-            ret i8* %ptr
+          %ptr = load i8*, i8** @__stderrp, align 8
+          ret i8* %ptr
         }
         """, "main"), Ptr{FILE}, Tuple{})
     end
@@ -236,8 +236,8 @@ else
 
         define i8* @main() {
         entry:
-            %ptr = load i8*, i8** @stderr, align 8
-            ret i8* %ptr
+          %ptr = load i8*, i8** @stderr, align 8
+          ret i8* %ptr
         }
         """, "main"), Ptr{FILE}, Tuple{})
     end
@@ -265,8 +265,8 @@ end
 
         define i8* @main() {
         entry:
-            %ptr = load i8*, i8** @__stdinp, align 8
-            ret i8* %ptr
+          %ptr = load i8*, i8** @__stdinp, align 8
+          ret i8* %ptr
         }
         """, "main"), Ptr{FILE}, Tuple{})
     end
@@ -277,8 +277,8 @@ else
 
         define i8* @main() {
         entry:
-            %ptr = load i8*, i8** @stdin, align 8
-            ret i8* %ptr
+          %ptr = load i8*, i8** @stdin, align 8
+          ret i8* %ptr
         }
         """, "main"), Ptr{FILE}, Tuple{})
     end
@@ -320,8 +320,8 @@ end
 
         define i32 @main(i8 %c) {
         entry:
-            %status = call i32 (i8) @putchar(i8 %c)
-            ret i32 0
+          %status = call i32 (i8) @putchar(i8 %c)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{UInt8}, c)
     end
@@ -333,8 +333,8 @@ end
 
         define i32 @main(i8* %fp, i8 %c) {
         entry:
-            %status = call i32 (i8, i8*) @fputc(i8 %c, i8* %fp)
-            ret i32 0
+          %status = call i32 (i8, i8*) @fputc(i8 %c, i8* %fp)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, UInt8}, fp, c)
     end
@@ -387,9 +387,9 @@ end
 
         define i8 @main() {
         entry:
-            %result = call i32 @getchar()
-            %c = trunc i32 %result to i8
-            ret i8 %c
+          %result = call i32 @getchar()
+          %c = trunc i32 %result to i8
+          ret i8 %c
         }
         """, "main"), UInt8, Tuple{})
     end
@@ -433,8 +433,8 @@ end
 
         define dso_local i32 @main(i8* %fp) #0 {
         entry:
-            %c = call i32 (i8*) @fgetc(i8* %fp)
-            ret i32 %c
+          %c = call i32 (i8*) @fgetc(i8* %fp)
+          ret i32 %c
         }
 
         attributes #0 = { nounwind uwtable }
@@ -475,9 +475,9 @@ end
 
         define i32 @main(i64 %jls) {
         entry:
-            %str = inttoptr i64 %jls to i8*
-            %status = call i32 (i8*) @puts(i8* %str)
-            ret i32 0
+          %str = inttoptr i64 %jls to i8*
+          %status = call i32 (i8*) @puts(i8* %str)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
     end
@@ -491,9 +491,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jls) {
         entry:
-            %str = inttoptr i64 %jls to i8*
-            %status = call i32 (i8*, i8*) @fputs(i8* %str, i8* %fp)
-            ret i32 0
+          %str = inttoptr i64 %jls to i8*
+          %status = call i32 (i8*, i8*) @fputs(i8* %str, i8* %fp)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, fp, s)
         newline(fp) # puts appends `\n`, but fputs doesn't (!)
@@ -531,9 +531,9 @@ end
 
         define i8* @main(i64 %jls, i8* %fp, i32 %n) #0 {
         entry:
-            %str = inttoptr i64 %jls to i8*
-            %status = call i8* (i8*, i32, i8*) @fgets(i8* %str, i32 %n, i8* %fp)
-            ret i8* %status
+          %str = inttoptr i64 %jls to i8*
+          %status = call i8* (i8*, i32, i8*) @fgets(i8* %str, i32 %n, i8* %fp)
+          ret i8* %status
         }
 
         attributes #0 = { noinline nounwind ssp uwtable }
@@ -577,9 +577,9 @@ end
 
         define i32 @main(i64 %jls) {
         entry:
-            %str = inttoptr i64 %jls to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %str)
-            ret i32 %status
+          %str = inttoptr i64 %jls to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %str)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
     end
@@ -590,9 +590,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jls) {
         entry:
-            %str = inttoptr i64 %jls to i8*
-            %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
-            ret i32 %status
+          %str = inttoptr i64 %jls to i8*
+          %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, fp, s)
     end
@@ -622,10 +622,10 @@ end
 
         define i32 @main(i64 %jlf, i64 %jls) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %str = inttoptr i64 %jls to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %fmt, i8* %str)
-            ret i32 0
+          %fmt = inttoptr i64 %jlf to i8*
+          %str = inttoptr i64 %jls to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %fmt, i8* %str)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}}, fmt, s)
     end
@@ -636,10 +636,10 @@ end
 
         define i32 @main(i8* %fp, i64 %jlf, i64 %jls) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %str = inttoptr i64 %jls to i8*
-            %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8* %str)
-            ret i32 %status
+          %fmt = inttoptr i64 %jlf to i8*
+          %str = inttoptr i64 %jls to i8*
+          %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8* %str)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, Ptr{UInt8}}, fp, fmt, s)
     end
@@ -659,9 +659,9 @@ end
 
         define i32 @main(i64 %jlf, double %d) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %fmt, double %d)
-            ret i32 0
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %fmt, double %d)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Float64}, fmt, n)
     end
@@ -672,9 +672,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jlf, double %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, double %n)
-            ret i32 %status
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, double %n)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, Float64}, fp, fmt, n)
     end
@@ -691,9 +691,9 @@ end
 
         define i32 @main(i64 %jlf, i64 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %fmt, i64 %n)
-            ret i32 0
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %fmt, i64 %n)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
@@ -704,9 +704,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jlf, i64 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i64 %n)
-            ret i32 %status
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i64 %n)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
@@ -718,9 +718,9 @@ end
 
         define i32 @main(i64 %jlf, i32 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %fmt, i32 %n)
-            ret i32 0
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %fmt, i32 %n)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
@@ -731,9 +731,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jlf, i32 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i32 %n)
-            ret i32 %status
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i32 %n)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
@@ -745,9 +745,9 @@ end
 
         define i32 @main(i64 %jlf, i16 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %fmt, i16 %n)
-            ret i32 0
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %fmt, i16 %n)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
@@ -758,9 +758,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jlf, i16 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i16 %n)
-            ret i32 %status
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i16 %n)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
@@ -772,9 +772,9 @@ end
 
         define i32 @main(i64 %jlf, i8 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @printf(i8* %fmt, i8 %n)
-            ret i32 0
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @printf(i8* %fmt, i8 %n)
+          ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
@@ -785,9 +785,9 @@ end
 
         define i32 @main(i8* %fp, i64 %jlf, i8 %n) {
         entry:
-            %fmt = inttoptr i64 %jlf to i8*
-            %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8 %n)
-            ret i32 %status
+          %fmt = inttoptr i64 %jlf to i8*
+          %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8 %n)
+          ret i32 %status
         }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -42,12 +42,13 @@
         ; External declaration of the fopen function
         declare i8* @fopen(i8*, i8*)
 
-        define i8* @main(i64 %jlname, i64 %jlmode) #0 {
+        define i64 @main(i64 %jlname, i64 %jlmode) #0 {
         entry:
           %name = inttoptr i64 %jlname to i8*
           %mode = inttoptr i64 %jlmode to i8*
           %fp = call i8* (i8*, i8*) @fopen(i8* %name, i8* %mode)
-          ret i8* %fp
+          %jlfp = ptrtoint i8* %fp to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -85,8 +86,9 @@
         ; External declaration of the fclose function
         declare i32 @fclose(i8*)
 
-        define i32 @main(i8* %fp) #0 {
+        define i32 @main(i64 %jlfp) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %status = call i32 (i8*) @fclose(i8* %fp)
           ret i32 %status
         }
@@ -144,8 +146,9 @@
         ; External declaration of the fseek function
         declare i32 @fseek(i8*, i64, i32)
 
-        define i32 @main(i8* %fp, i64 %offset, i32 %whence) #0 {
+        define i32 @main(i64 %jlfp, i64 %offset, i32 %whence) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %status = call i32 @fseek(i8* %fp, i64 %offset, i32 %whence)
           ret i32 %status
         }
@@ -183,10 +186,11 @@
         Base.llvmcall(("""
         @__stdoutp = external global i8*
 
-        define i8* @main() #0 {
+        define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stdoutp, align 8
-          ret i8* %ptr
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -197,10 +201,11 @@ else
         Base.llvmcall(("""
         @stdout = external global i8*
 
-        define i8* @main() #0 {
+        define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @stdout, align 8
-          ret i8* %ptr
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -232,10 +237,11 @@ end
         Base.llvmcall(("""
         @__stderrp = external global i8*
 
-        define i8* @main() #0 {
+        define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stderrp, align 8
-          ret i8* %ptr
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -246,10 +252,11 @@ else
         Base.llvmcall(("""
         @stderr = external global i8*
 
-        define i8* @main() #0 {
+        define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @stderr, align 8
-          ret i8* %ptr
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -277,10 +284,11 @@ end
         Base.llvmcall(("""
         @__stdinp = external global i8*
 
-        define i8* @main() #0 {
+        define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stdinp, align 8
-          ret i8* %ptr
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -291,10 +299,11 @@ else
         Base.llvmcall(("""
         @stdin = external global i8*
 
-        define i8* @main() #0 {
+        define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @stdin, align 8
-          ret i8* %ptr
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
         }
 
         attributes #0 = { nounwind ssp uwtable }
@@ -351,8 +360,9 @@ end
         ; External declaration of the fputc function
         declare i32 @fputc(i8, i8*) nounwind
 
-        define i32 @main(i8* %fp, i8 %c) #0 {
+        define i32 @main(i64 %jlfp, i8 %c) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %status = call i32 (i8, i8*) @fputc(i8 %c, i8* %fp)
           ret i32 0
         }
@@ -418,21 +428,6 @@ end
         """, "main"), UInt8, Tuple{})
     end
 
-    # function getchar(fp::Ptr{FILE})
-    #     Base.llvmcall(("""
-    #     ; External declaration of the fgetc function
-    #     declare i32 @fgetc(i8*)
-    #
-    #     define dso_local i8 @main(i8* %fp) #0 {
-    #     entry:
-    #         %result = call i32 (i8*) @fgetc(i8* %fp)
-    #         %c = trunc i32 %result to i8
-    #         ret i8 %c
-    #     }
-    #
-    #     attributes #0 = { nounwind uwtable }
-    #     """, "main"), UInt8, Tuple{Ptr{FILE}}, fp)
-    # end
 
     """
     ```julia
@@ -455,8 +450,9 @@ end
         ; External declaration of the fgetc function
         declare i32 @fgetc(i8*)
 
-        define dso_local i32 @main(i8* %fp) #0 {
+        define dso_local i32 @main(i64 %jlfp) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %c = call i32 (i8*) @fgetc(i8* %fp)
           ret i32 %c
         }
@@ -515,8 +511,9 @@ end
         ; External declaration of the puts function
         declare i32 @fputs(i8*, i8*) nounwind
 
-        define i32 @main(i8* %fp, i64 %jls) #0 {
+        define i32 @main(i64 %jlfp, i64 %jls) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, i8*) @fputs(i8* %str, i8* %fp)
           ret i32 0
@@ -557,9 +554,10 @@ end
         ; External declaration of the gets function
         declare i8* @fgets(i8*, i32, i8*)
 
-        define i8* @main(i64 %jls, i8* %fp, i32 %n) #0 {
+        define i8* @main(i64 %jls, i64 %jlfp, i32 %n) #0 {
         entry:
           %str = inttoptr i64 %jls to i8*
+          %fp = inttoptr i64 %jlfp to i8*
           %status = call i8* (i8*, i32, i8*) @fgets(i8* %str, i32 %n, i8* %fp)
           ret i8* %status
         }
@@ -618,8 +616,9 @@ end
         ; External declaration of the fprintf function
         declare i32 @fprintf(i8*, i8*)
 
-        define i32 @main(i8* %fp, i64 %jls) #0 {
+        define i32 @main(i64 %jlfp, i64 %jls) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
           ret i32 %status
@@ -668,8 +667,9 @@ end
         ; External declaration of the fprintf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i64 %jls) #0 {
+        define i32 @main(i64 %jlfp, i64 %jlf, i64 %jls) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %fmt = inttoptr i64 %jlf to i8*
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8* %str)
@@ -708,8 +708,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, double %n) #0 {
+        define i32 @main(i64 %jlfp, i64 %jlf, double %n) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, double %n)
           ret i32 %status
@@ -744,8 +745,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i64 %n) #0 {
+        define i32 @main(i64 %jlfp, i64 %jlf, i64 %n) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i64 %n)
           ret i32 %status
@@ -775,8 +777,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i32 %n) #0 {
+        define i32 @main(i64 %jlfp, i64 %jlf, i32 %n) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i32 %n)
           ret i32 %status
@@ -806,8 +809,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i16 %n) #0 {
+        define i32 @main(i64 %jlfp, i64 %jlf, i16 %n) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i16 %n)
           ret i32 %status
@@ -837,8 +841,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i8 %n) #0 {
+        define i32 @main(i64 %jlfp, i64 %jlf, i8 %n) #0 {
         entry:
+          %fp = inttoptr i64 %jlfp to i8*
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8 %n)
           ret i32 %status

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -51,7 +51,7 @@
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{Ptr{UInt8}, Ptr{UInt8}}, name, mode)
     end
 
@@ -93,7 +93,7 @@
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}}, fp)
     end
 
@@ -153,7 +153,7 @@
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Int64, Int32}, fp, offset, whence)
     end
     const SEEK_SET = Int32(0)
@@ -193,7 +193,7 @@
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 else
@@ -208,7 +208,7 @@ else
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 end
@@ -244,7 +244,7 @@ end
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 else
@@ -259,7 +259,7 @@ else
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 end
@@ -291,7 +291,7 @@ end
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 else
@@ -306,7 +306,7 @@ else
           ret i64 %jlfp
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 end
@@ -351,7 +351,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{UInt8}, c)
     end
     putchar(fp::Ptr{FILE}, c::Char) = putchar(fp, UInt8(c))
@@ -367,7 +367,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, UInt8}, fp, c)
     end
 
@@ -424,7 +424,7 @@ end
           ret i8 %c
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), UInt8, Tuple{})
     end
 
@@ -457,7 +457,7 @@ end
           ret i32 %c
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}}, fp)
     end
     const EOF = Int32(-1)
@@ -500,7 +500,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
     end
 
@@ -519,7 +519,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, fp, s)
         newline(fp) # puts appends `\n`, but fputs doesn't (!)
     end
@@ -563,7 +563,7 @@ end
           ret i64 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{UInt8}, Tuple{Ptr{UInt8}, Ptr{FILE}, Int32}, pointer(s), fp, n % Int32)
     end
 
@@ -609,7 +609,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
     end
     function printf(fp::Ptr{FILE}, s::Ptr{UInt8})
@@ -625,7 +625,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, fp, s)
     end
     function printf(s::StringView)
@@ -660,7 +660,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}}, fmt, s)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, s::Ptr{UInt8})
@@ -677,7 +677,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, Ptr{UInt8}}, fp, fmt, s)
     end
 
@@ -701,7 +701,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Float64}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::Float64)
@@ -717,7 +717,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, Float64}, fp, fmt, n)
     end
 
@@ -738,7 +738,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int64, UInt64, Ptr}
@@ -754,7 +754,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 
@@ -770,7 +770,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int32, UInt32}
@@ -786,7 +786,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 
@@ -802,7 +802,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int16, UInt16}
@@ -818,7 +818,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 
@@ -834,7 +834,7 @@ end
           ret i32 0
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int8, UInt8}
@@ -850,7 +850,7 @@ end
           ret i32 %status
         }
 
-        attributes #0 = { nounwind ssp uwtable }
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -42,13 +42,15 @@
         ; External declaration of the fopen function
         declare i8* @fopen(i8*, i8*)
 
-        define i8* @main(i64 %jlname, i64 %jlmode) {
+        define i8* @main(i64 %jlname, i64 %jlmode) #0 {
         entry:
           %name = inttoptr i64 %jlname to i8*
           %mode = inttoptr i64 %jlmode to i8*
           %fp = call i8* (i8*, i8*) @fopen(i8* %name, i8* %mode)
           ret i8* %fp
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{Ptr{UInt8}, Ptr{UInt8}}, name, mode)
     end
 
@@ -83,11 +85,13 @@
         ; External declaration of the fclose function
         declare i32 @fclose(i8*)
 
-        define i32 @main(i8* %fp) {
+        define i32 @main(i8* %fp) #0 {
         entry:
           %status = call i32 (i8*) @fclose(i8* %fp)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}}, fp)
     end
 
@@ -140,11 +144,13 @@
         ; External declaration of the fseek function
         declare i32 @fseek(i8*, i64, i32)
 
-        define i32 @main(i8* %fp, i64 %offset, i32 %whence) {
+        define i32 @main(i8* %fp, i64 %offset, i32 %whence) #0 {
         entry:
           %status = call i32 @fseek(i8* %fp, i64 %offset, i32 %whence)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Int64, Int32}, fp, offset, whence)
     end
     const SEEK_SET = Int32(0)
@@ -177,11 +183,13 @@
         Base.llvmcall(("""
         @__stdoutp = external global i8*
 
-        define i8* @main() {
+        define i8* @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stdoutp, align 8
           ret i8* %ptr
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 else
@@ -189,11 +197,13 @@ else
         Base.llvmcall(("""
         @stdout = external global i8*
 
-        define i8* @main() {
+        define i8* @main() #0 {
         entry:
           %ptr = load i8*, i8** @stdout, align 8
           ret i8* %ptr
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 end
@@ -222,11 +232,13 @@ end
         Base.llvmcall(("""
         @__stderrp = external global i8*
 
-        define i8* @main() {
+        define i8* @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stderrp, align 8
           ret i8* %ptr
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 else
@@ -234,11 +246,13 @@ else
         Base.llvmcall(("""
         @stderr = external global i8*
 
-        define i8* @main() {
+        define i8* @main() #0 {
         entry:
           %ptr = load i8*, i8** @stderr, align 8
           ret i8* %ptr
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 end
@@ -263,11 +277,13 @@ end
         Base.llvmcall(("""
         @__stdinp = external global i8*
 
-        define i8* @main() {
+        define i8* @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stdinp, align 8
           ret i8* %ptr
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 else
@@ -275,11 +291,13 @@ else
         Base.llvmcall(("""
         @stdin = external global i8*
 
-        define i8* @main() {
+        define i8* @main() #0 {
         entry:
           %ptr = load i8*, i8** @stdin, align 8
           ret i8* %ptr
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
 end
@@ -318,11 +336,13 @@ end
         ; External declaration of the putchar function
         declare i32 @putchar(i8 nocapture) nounwind
 
-        define i32 @main(i8 %c) {
+        define i32 @main(i8 %c) #0 {
         entry:
           %status = call i32 (i8) @putchar(i8 %c)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{UInt8}, c)
     end
     putchar(fp::Ptr{FILE}, c::Char) = putchar(fp, UInt8(c))
@@ -331,11 +351,13 @@ end
         ; External declaration of the fputc function
         declare i32 @fputc(i8, i8*) nounwind
 
-        define i32 @main(i8* %fp, i8 %c) {
+        define i32 @main(i8* %fp, i8 %c) #0 {
         entry:
           %status = call i32 (i8, i8*) @fputc(i8 %c, i8* %fp)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, UInt8}, fp, c)
     end
 
@@ -385,12 +407,14 @@ end
         ; External declaration of the getchar function
         declare i32 @getchar()
 
-        define i8 @main() {
+        define i8 @main() #0 {
         entry:
           %result = call i32 @getchar()
           %c = trunc i32 %result to i8
           ret i8 %c
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), UInt8, Tuple{})
     end
 
@@ -473,12 +497,14 @@ end
         ; External declaration of the puts function
         declare i32 @puts(i8* nocapture) nounwind
 
-        define i32 @main(i64 %jls) {
+        define i32 @main(i64 %jls) #0 {
         entry:
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*) @puts(i8* %str)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
     end
 
@@ -489,12 +515,14 @@ end
         ; External declaration of the puts function
         declare i32 @fputs(i8*, i8*) nounwind
 
-        define i32 @main(i8* %fp, i64 %jls) {
+        define i32 @main(i8* %fp, i64 %jls) #0 {
         entry:
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, i8*) @fputs(i8* %str, i8* %fp)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, fp, s)
         newline(fp) # puts appends `\n`, but fputs doesn't (!)
     end
@@ -575,12 +603,14 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jls) {
+        define i32 @main(i64 %jls) #0 {
         entry:
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, ...) @printf(i8* %str)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
     end
     function printf(fp::Ptr{FILE}, s::Ptr{UInt8})
@@ -588,12 +618,14 @@ end
         ; External declaration of the fprintf function
         declare i32 @fprintf(i8*, i8*)
 
-        define i32 @main(i8* %fp, i64 %jls) {
+        define i32 @main(i8* %fp, i64 %jls) #0 {
         entry:
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, fp, s)
     end
     function printf(s::StringView)
@@ -620,13 +652,15 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jlf, i64 %jls) {
+        define i32 @main(i64 %jlf, i64 %jls) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, ...) @printf(i8* %fmt, i8* %str)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}}, fmt, s)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, s::Ptr{UInt8})
@@ -634,13 +668,15 @@ end
         ; External declaration of the fprintf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i64 %jls) {
+        define i32 @main(i8* %fp, i64 %jlf, i64 %jls) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %str = inttoptr i64 %jls to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8* %str)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, Ptr{UInt8}}, fp, fmt, s)
     end
 
@@ -657,12 +693,14 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jlf, double %d) {
+        define i32 @main(i64 %jlf, double %d) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @printf(i8* %fmt, double %d)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Float64}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::Float64)
@@ -670,12 +708,14 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, double %n) {
+        define i32 @main(i8* %fp, i64 %jlf, double %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, double %n)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, Float64}, fp, fmt, n)
     end
 
@@ -689,12 +729,14 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jlf, i64 %n) {
+        define i32 @main(i64 %jlf, i64 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @printf(i8* %fmt, i64 %n)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int64, UInt64, Ptr}
@@ -702,12 +744,14 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i64 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i64 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i64 %n)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 
@@ -716,12 +760,14 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jlf, i32 %n) {
+        define i32 @main(i64 %jlf, i32 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @printf(i8* %fmt, i32 %n)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int32, UInt32}
@@ -729,12 +775,14 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i32 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i32 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i32 %n)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 
@@ -743,12 +791,14 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jlf, i16 %n) {
+        define i32 @main(i64 %jlf, i16 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @printf(i8* %fmt, i16 %n)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int16, UInt16}
@@ -756,12 +806,14 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i16 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i16 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i16 %n)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 
@@ -770,12 +822,14 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i64 %jlf, i8 %n) {
+        define i32 @main(i64 %jlf, i8 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @printf(i8* %fmt, i8 %n)
           ret i32 0
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
     end
     function printf(fp::Ptr{FILE}, fmt::Ptr{UInt8}, n::T) where T <: Union{Int8, UInt8}
@@ -783,12 +837,14 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i64 %jlf, i8 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i8 %n) #0 {
         entry:
           %fmt = inttoptr i64 %jlf to i8*
           %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8 %n)
           ret i32 %status
         }
+
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}, T}, fp, fmt, n)
     end
 

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -450,7 +450,7 @@ end
         ; External declaration of the fgetc function
         declare i32 @fgetc(i8*)
 
-        define dso_local i32 @main(i64 %jlfp) #0 {
+        define i32 @main(i64 %jlfp) #0 {
         entry:
           %fp = inttoptr i64 %jlfp to i8*
           %c = call i32 (i8*) @fgetc(i8* %fp)

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -42,8 +42,10 @@
         ; External declaration of the fopen function
         declare i8* @fopen(i8*, i8*)
 
-        define i8* @main(i8* %name, i8* %mode) {
+        define i8* @main(i64 %jlname, i64 %jlmode) {
         entry:
+            %name = inttoptr i64 %jlname to i8*
+            %mode = inttoptr i64 %jlmode to i8*
             %fp = call i8* (i8*, i8*) @fopen(i8* %name, i8* %mode)
             ret i8* %fp
         }
@@ -316,9 +318,9 @@ end
         ; External declaration of the putchar function
         declare i32 @putchar(i8 nocapture) nounwind
 
-        define i32 @main(i8) {
+        define i32 @main(i8 %c) {
         entry:
-            %status = call i32 (i8) @putchar(i8 %0)
+            %status = call i32 (i8) @putchar(i8 %c)
             ret i32 0
         }
         """, "main"), Int32, Tuple{UInt8}, c)
@@ -471,9 +473,10 @@ end
         ; External declaration of the puts function
         declare i32 @puts(i8* nocapture) nounwind
 
-        define i32 @main(i8*) {
+        define i32 @main(i64 %jls) {
         entry:
-            %status = call i32 (i8*) @puts(i8* %0)
+            %str = inttoptr i64 %jls to i8*
+            %status = call i32 (i8*) @puts(i8* %str)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
@@ -486,8 +489,9 @@ end
         ; External declaration of the puts function
         declare i32 @fputs(i8*, i8*) nounwind
 
-        define i32 @main(i8* %fp, i8* %str) {
+        define i32 @main(i8* %fp, i64 %jls) {
         entry:
+            %str = inttoptr i64 %jls to i8*
             %status = call i32 (i8*, i8*) @fputs(i8* %str, i8* %fp)
             ret i32 0
         }
@@ -525,8 +529,9 @@ end
         ; External declaration of the gets function
         declare i8* @fgets(i8*, i32, i8*)
 
-        define i8* @main(i8* %str, i8* %fp, i32 %n) #0 {
+        define i8* @main(i64 %jls, i8* %fp, i32 %n) #0 {
         entry:
+            %str = inttoptr i64 %jls to i8*
             %status = call i8* (i8*, i32, i8*) @fgets(i8* %str, i32 %n, i8* %fp)
             ret i8* %status
         }
@@ -570,8 +575,9 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8* %str) {
+        define i32 @main(i64 %jls) {
         entry:
+            %str = inttoptr i64 %jls to i8*
             %status = call i32 (i8*, ...) @printf(i8* %str)
             ret i32 %status
         }
@@ -582,8 +588,9 @@ end
         ; External declaration of the fprintf function
         declare i32 @fprintf(i8*, i8*)
 
-        define i32 @main(i8* %fp, i8* %str) {
+        define i32 @main(i8* %fp, i64 %jls) {
         entry:
+            %str = inttoptr i64 %jls to i8*
             %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
             ret i32 %status
         }
@@ -613,9 +620,11 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8*, i8*) {
+        define i32 @main(i64 %jlf, i64 %jls) {
         entry:
-            %status = call i32 (i8*, ...) @printf(i8* %0, i8* %1)
+            %fmt = inttoptr i64 %jlf to i8*
+            %str = inttoptr i64 %jls to i8*
+            %status = call i32 (i8*, ...) @printf(i8* %fmt, i8* %str)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}}, fmt, s)
@@ -625,8 +634,10 @@ end
         ; External declaration of the fprintf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i8* %fmt, i8* %str) {
+        define i32 @main(i8* %fp, i64 %jlf, i64 %jls) {
         entry:
+            %fmt = inttoptr i64 %jlf to i8*
+            %str = inttoptr i64 %jls to i8*
             %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8* %str)
             ret i32 %status
         }
@@ -646,9 +657,10 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8*, double) {
+        define i32 @main(i64 %jlf, double %d) {
         entry:
-            %status = call i32 (i8*, ...) @printf(i8* %0, double %1)
+            %fmt = inttoptr i64 %jlf to i8*
+            %status = call i32 (i8*, ...) @printf(i8* %fmt, double %d)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, Float64}, fmt, n)
@@ -658,8 +670,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i8* %fmt, double %n) {
+        define i32 @main(i8* %fp, i64 %jlf, double %n) {
         entry:
+            %fmt = inttoptr i64 %jlf to i8*
             %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, double %n)
             ret i32 %status
         }
@@ -676,9 +689,10 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8*, i64) {
+        define i32 @main(i64 %jlf, i64 %n) {
         entry:
-            %status = call i32 (i8*, ...) @printf(i8* %0, i64 %1)
+            %fmt = inttoptr i64 %jlf to i8*
+            %status = call i32 (i8*, ...) @printf(i8* %fmt, i64 %n)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
@@ -688,8 +702,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i8* %fmt, i64 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i64 %n) {
         entry:
+            %fmt = inttoptr i64 %jlf to i8*
             %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i64 %n)
             ret i32 %status
         }
@@ -701,9 +716,10 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8*, i32) {
+        define i32 @main(i64 %jlf, i32 %n) {
         entry:
-            %status = call i32 (i8*, ...) @printf(i8* %0, i32 %1)
+            %fmt = inttoptr i64 %jlf to i8*
+            %status = call i32 (i8*, ...) @printf(i8* %fmt, i32 %n)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
@@ -713,8 +729,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i8* %fmt, i32 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i32 %n) {
         entry:
+            %fmt = inttoptr i64 %jlf to i8*
             %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i32 %n)
             ret i32 %status
         }
@@ -726,9 +743,10 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8*, i16) {
+        define i32 @main(i64 %jlf, i16 %n) {
         entry:
-            %status = call i32 (i8*, ...) @printf(i8* %0, i16 %1)
+            %fmt = inttoptr i64 %jlf to i8*
+            %status = call i32 (i8*, ...) @printf(i8* %fmt, i16 %n)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
@@ -738,8 +756,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i8* %fmt, i16 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i16 %n) {
         entry:
+            %fmt = inttoptr i64 %jlf to i8*
             %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i16 %n)
             ret i32 %status
         }
@@ -751,9 +770,10 @@ end
         ; External declaration of the printf function
         declare i32 @printf(i8* noalias nocapture, ...)
 
-        define i32 @main(i8*, i8) {
+        define i32 @main(i64 %jlf, i8 %n) {
         entry:
-            %status = call i32 (i8*, ...) @printf(i8* %0, i8 %1)
+            %fmt = inttoptr i64 %jlf to i8*
+            %status = call i32 (i8*, ...) @printf(i8* %fmt, i8 %n)
             ret i32 0
         }
         """, "main"), Int32, Tuple{Ptr{UInt8}, T}, fmt, n)
@@ -763,8 +783,9 @@ end
         ; External declaration of the printf function
         declare i32 @fprintf(i8*, ...)
 
-        define i32 @main(i8* %fp, i8* %fmt, i8 %n) {
+        define i32 @main(i8* %fp, i64 %jlf, i8 %n) {
         entry:
+            %fmt = inttoptr i64 %jlf to i8*
             %status = call i32 (i8*, ...) @fprintf(i8* %fp, i8* %fmt, i8 %n)
             ret i32 %status
         }

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -536,7 +536,7 @@ end
           ret i8* %status
         }
 
-        attributes #0 = { noinline nounwind ssp uwtable }
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Ptr{UInt8}, Tuple{Ptr{UInt8}, Ptr{FILE}, Int32}, pointer(s), fp, n % Int32)
     end
 

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -457,7 +457,7 @@ end
           ret i32 %c
         }
 
-        attributes #0 = { nounwind uwtable }
+        attributes #0 = { nounwind ssp uwtable }
         """, "main"), Int32, Tuple{Ptr{FILE}}, fp)
     end
     const EOF = Int32(-1)

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -554,12 +554,13 @@ end
         ; External declaration of the gets function
         declare i8* @fgets(i8*, i32, i8*)
 
-        define i8* @main(i64 %jls, i64 %jlfp, i32 %n) #0 {
+        define i64 @main(i64 %jls, i64 %jlfp, i32 %n) #0 {
         entry:
           %str = inttoptr i64 %jls to i8*
           %fp = inttoptr i64 %jlfp to i8*
-          %status = call i8* (i8*, i32, i8*) @fgets(i8* %str, i32 %n, i8* %fp)
-          ret i8* %status
+          %stp = call i8* (i8*, i32, i8*) @fgets(i8* %str, i32 %n, i8* %fp)
+          %status = ptrtoint i8* %stp to i64
+          ret i64 %status
         }
 
         attributes #0 = { nounwind ssp uwtable }

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -23,14 +23,14 @@ julia> free(p)
     ; External declaration of the `malloc` function
     declare i8* @malloc(i64)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main(i64 %size) #0 {
       %ptr = call i8* (i64) @malloc(i64 %size)
       %jlp = ptrtoint i8* %ptr to i64
       ret i64 %jlp
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Ptr{UInt8}, Tuple{Int64}, size)
 end
 @inline malloc(size::Unsigned) = malloc(UInt64(size))
@@ -39,14 +39,14 @@ end
     ; External declaration of the `malloc` function
     declare i8* @malloc(i64)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main(i64 %size) #0 {
       %ptr = call i8* (i64) @malloc(i64 %size)
       %jlp = ptrtoint i8* %ptr to i64
       ret i64 %jlp
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Ptr{UInt8}, Tuple{UInt64}, size)
 end
 
@@ -91,14 +91,14 @@ julia> free(p)
     ; External declaration of the `calloc` function
     declare i8* @calloc(i64, i64)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main(i64 %n, i64 %size) #0 {
       %ptr = call i8* (i64, i64) @calloc(i64 %n, i64 %size)
       %jlp = ptrtoint i8* %ptr to i64
       ret i64 %jlp
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Ptr{UInt8}, Tuple{Int64, Int64}, n, size)
 end
 
@@ -128,14 +128,14 @@ julia> free(p)
     ; External declaration of the `free` function
     declare void @free(i8*)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i32 @main(i64 %jlp) #0 {
       %ptr = inttoptr i64 %jlp to i8*
       call void (i8*) @free(i8* %ptr)
       ret i32 0
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}}, ptr)
 end
 
@@ -181,7 +181,7 @@ julia> a
     ; Function Attrs: argmemonly nounwind
     declare void @memset(i8* nocapture writeonly, i64, i64) #0
 
-    ; Function Attrs: noinline nounwind ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i32 @main(i64 %jlp, i64 %value, i64 %n) #1 {
       %ptr = inttoptr i64 %jlp to i8*
       call void @memset(i8* %ptr, i64 %value, i64 %n)
@@ -189,7 +189,7 @@ julia> a
     }
 
     attributes #0 = { argmemonly nounwind }
-    attributes #1 = { noinline nounwind ssp uwtable }
+    attributes #1 = { nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}, Int64, Int64}, ptr, char, nbytes)
 end
 
@@ -229,7 +229,7 @@ julia> a
     ; Function Attrs: argmemonly nounwind
     declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #0
 
-    ; Function Attrs: noinline nounwind ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i32 @main(i64 %jldest, i64 %jlsrc, i64 %nbytes) #1 {
       %dest = inttoptr i64 %jldest to i8*
       %src = inttoptr i64 %jlsrc to i8*
@@ -238,7 +238,7 @@ julia> a
     }
 
     attributes #0 = { argmemonly nounwind }
-    attributes #1 = { noinline nounwind ssp uwtable }
+    attributes #1 = { nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}, Int64}, dst, src, nbytes)
 end
 
@@ -269,7 +269,7 @@ julia> memcmp(c"foo", c"bar", 3)
     ; External declaration of the `memcmp` function
     declare i32 @memcmp(i8*, i8*, i64)
 
-    ; Function Attrs: noinline nounwind ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i32 @main(i64 %jla, i64 %jlb, i64 %nbytes) #0 {
       %a = inttoptr i64 %jla to i8*
       %b = inttoptr i64 %jlb to i8*
@@ -277,7 +277,7 @@ julia> memcmp(c"foo", c"bar", 3)
       ret i32 %cmp
     }
 
-    attributes #0 = { noinline nounwind ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}, Int64}, a, b, nbytes)
 end
 
@@ -302,7 +302,7 @@ julia> StaticTools.time()
     ; External declaration of the `time` function
     declare i64 @time(i64*)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main() {
       %time = call i64 @time(i64* null)
       ret i64 %time
@@ -331,13 +331,13 @@ julia> usleep(1000000)
     ; External declaration of the `usleep` function
     declare i32 @usleep(i64)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i32 @main(i64 %usec) #0 {
       %status = call i32 (i64) @usleep(i64 %usec)
       ret i32 %status
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Int64}, μsec)
 end
 
@@ -371,14 +371,14 @@ sys 0m0.000s
     ; External declaration of the `system` function
     declare i32 @system(...)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i32 @main(i64 %jlstr) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %status = call i32 (i8*, ...) bitcast (i32 (...)* @system to i32 (i8*, ...)*)(i8* %str)
       ret i32 %status
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
 end
 
@@ -407,14 +407,14 @@ julia> strlen(c"foo")
     ; External declaration of the `strlen` function
     declare i64 @strlen(i8*)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main(i64 %jlstr) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %li = call i64 (i8*) @strlen (i8* %str)
       ret i64 %li
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Int64, Tuple{Ptr{UInt8}}, s)
 end
 
@@ -449,7 +449,7 @@ end
     ; External declaration of the `strtod` function
     declare double @strtod(i8*, i8**)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local double @main(i64 %jlstr, i64 %jlp) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %ptr = inttoptr i64 %jlp to i8**
@@ -457,7 +457,7 @@ end
       ret double %d
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Float64, Tuple{Ptr{UInt8}, Ptr{Ptr{UInt8}}}, s, p)
 end
 
@@ -491,7 +491,7 @@ end
     ; External declaration of the `strtol` function
     declare i64 @strtol(i8*, i8**, i32)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %ptr = inttoptr i64 %jlp to i8**
@@ -499,7 +499,7 @@ end
       ret i64 %li
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), Int64, Tuple{Ptr{UInt8}, Ptr{Ptr{UInt8}}, Int32}, s, p, base)
 end
 
@@ -533,7 +533,7 @@ end
     ; External declaration of the `strtoul` function
     declare i64 @strtoul(i8*, i8**, i32)
 
-    ; Function Attrs: noinline nounwind optnone ssp uwtable
+    ; Function Attrs: nounwind ssp uwtable
     define dso_local i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %ptr = inttoptr i64 %jlp to i8**
@@ -541,7 +541,7 @@ end
       ret i64 %li
     }
 
-    attributes #0 = { noinline nounwind optnone ssp uwtable }
+    attributes #0 = { nounwind ssp uwtable }
     """, "main"), UInt64, Tuple{Ptr{UInt8}, Ptr{Ptr{UInt8}}, Int32}, s, p, base)
 end
 

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -450,7 +450,9 @@ end
     declare double @strtod(i8*, i8**)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local double @main(i8* %str, i8** %ptr) #0 {
+    define dso_local double @main(i64 %jlstr, i64 %jlp) #0 {
+      %str = inttoptr i64 %jlstr to i8*
+      %ptr = inttoptr i64 %jlp to i8**
       %d = call double (i8*, i8**) @strtod (i8* %str, i8** %ptr)
       ret double %d
     }
@@ -490,7 +492,9 @@ end
     declare i64 @strtol(i8*, i8**, i32)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i64 @main(i8* %str, i8** %ptr, i32 %base) #0 {
+    define dso_local i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
+      %str = inttoptr i64 %jlstr to i8*
+      %ptr = inttoptr i64 %jlp to i8**
       %li = call i64 (i8*, i8**, i32) @strtol (i8* %str, i8** %ptr, i32 %base)
       ret i64 %li
     }
@@ -530,7 +534,9 @@ end
     declare i64 @strtoul(i8*, i8**, i32)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i64 @main(i8* %str, i8** %ptr, i32 %base) #0 {
+    define dso_local i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
+      %str = inttoptr i64 %jlstr to i8*
+      %ptr = inttoptr i64 %jlp to i8**
       %li = call i64 (i8*, i8**, i32) @strtoul (i8* %str, i8** %ptr, i32 %base)
       ret i64 %li
     }

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -375,7 +375,7 @@ sys 0m0.000s
     define dso_local i32 @main(i64 %jlstr) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %status = call i32 (i8*, ...) bitcast (i32 (...)* @system to i32 (i8*, ...)*)(i8* %str)
-      ret i32 0
+      ret i32 %status
     }
 
     attributes #0 = { noinline nounwind optnone ssp uwtable }

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -30,7 +30,7 @@ julia> free(p)
       ret i64 %jlp
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Ptr{UInt8}, Tuple{Int64}, size)
 end
 @inline malloc(size::Unsigned) = malloc(UInt64(size))
@@ -46,7 +46,7 @@ end
       ret i64 %jlp
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Ptr{UInt8}, Tuple{UInt64}, size)
 end
 
@@ -98,7 +98,7 @@ julia> free(p)
       ret i64 %jlp
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Ptr{UInt8}, Tuple{Int64, Int64}, n, size)
 end
 
@@ -135,7 +135,7 @@ julia> free(p)
       ret i32 0
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}}, ptr)
 end
 
@@ -189,7 +189,7 @@ julia> a
     }
 
     attributes #0 = { argmemonly nounwind }
-    attributes #1 = { nounwind ssp uwtable }
+    attributes #1 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}, Int64, Int64}, ptr, char, nbytes)
 end
 
@@ -238,7 +238,7 @@ julia> a
     }
 
     attributes #0 = { argmemonly nounwind }
-    attributes #1 = { nounwind ssp uwtable }
+    attributes #1 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}, Int64}, dst, src, nbytes)
 end
 
@@ -277,7 +277,7 @@ julia> memcmp(c"foo", c"bar", 3)
       ret i32 %cmp
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}, Ptr{UInt8}, Int64}, a, b, nbytes)
 end
 
@@ -337,7 +337,7 @@ julia> usleep(1000000)
       ret i32 %status
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Int64}, μsec)
 end
 
@@ -378,7 +378,7 @@ sys 0m0.000s
       ret i32 %status
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
 end
 
@@ -414,7 +414,7 @@ julia> strlen(c"foo")
       ret i64 %li
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int64, Tuple{Ptr{UInt8}}, s)
 end
 
@@ -457,7 +457,7 @@ end
       ret double %d
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Float64, Tuple{Ptr{UInt8}, Ptr{Ptr{UInt8}}}, s, p)
 end
 
@@ -499,7 +499,7 @@ end
       ret i64 %li
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int64, Tuple{Ptr{UInt8}, Ptr{Ptr{UInt8}}, Int32}, s, p, base)
 end
 
@@ -541,7 +541,7 @@ end
       ret i64 %li
     }
 
-    attributes #0 = { nounwind ssp uwtable }
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), UInt64, Tuple{Ptr{UInt8}, Ptr{Ptr{UInt8}}, Int32}, s, p, base)
 end
 

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -24,7 +24,7 @@ julia> free(p)
     declare i8* @malloc(i64)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main(i64 %size) #0 {
+    define i64 @main(i64 %size) #0 {
       %ptr = call i8* (i64) @malloc(i64 %size)
       %jlp = ptrtoint i8* %ptr to i64
       ret i64 %jlp
@@ -40,7 +40,7 @@ end
     declare i8* @malloc(i64)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main(i64 %size) #0 {
+    define i64 @main(i64 %size) #0 {
       %ptr = call i8* (i64) @malloc(i64 %size)
       %jlp = ptrtoint i8* %ptr to i64
       ret i64 %jlp
@@ -92,7 +92,7 @@ julia> free(p)
     declare i8* @calloc(i64, i64)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main(i64 %n, i64 %size) #0 {
+    define i64 @main(i64 %n, i64 %size) #0 {
       %ptr = call i8* (i64, i64) @calloc(i64 %n, i64 %size)
       %jlp = ptrtoint i8* %ptr to i64
       ret i64 %jlp
@@ -129,7 +129,7 @@ julia> free(p)
     declare void @free(i8*)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i32 @main(i64 %jlp) #0 {
+    define i32 @main(i64 %jlp) #0 {
       %ptr = inttoptr i64 %jlp to i8*
       call void (i8*) @free(i8* %ptr)
       ret i32 0
@@ -182,7 +182,7 @@ julia> a
     declare void @memset(i8* nocapture writeonly, i64, i64) #0
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i32 @main(i64 %jlp, i64 %value, i64 %n) #1 {
+    define i32 @main(i64 %jlp, i64 %value, i64 %n) #1 {
       %ptr = inttoptr i64 %jlp to i8*
       call void @memset(i8* %ptr, i64 %value, i64 %n)
       ret i32 0
@@ -230,7 +230,7 @@ julia> a
     declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #0
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i32 @main(i64 %jldest, i64 %jlsrc, i64 %nbytes) #1 {
+    define i32 @main(i64 %jldest, i64 %jlsrc, i64 %nbytes) #1 {
       %dest = inttoptr i64 %jldest to i8*
       %src = inttoptr i64 %jlsrc to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dest, i8* %src, i64 %nbytes, i1 false)
@@ -270,7 +270,7 @@ julia> memcmp(c"foo", c"bar", 3)
     declare i32 @memcmp(i8*, i8*, i64)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i32 @main(i64 %jla, i64 %jlb, i64 %nbytes) #0 {
+    define i32 @main(i64 %jla, i64 %jlb, i64 %nbytes) #0 {
       %a = inttoptr i64 %jla to i8*
       %b = inttoptr i64 %jlb to i8*
       %cmp = call i32 @memcmp(i8* %a, i8* %b, i64 %nbytes)
@@ -303,7 +303,7 @@ julia> StaticTools.time()
     declare i64 @time(i64*)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main() {
+    define i64 @main() {
       %time = call i64 @time(i64* null)
       ret i64 %time
     }
@@ -332,7 +332,7 @@ julia> usleep(1000000)
     declare i32 @usleep(i64)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i32 @main(i64 %usec) #0 {
+    define i32 @main(i64 %usec) #0 {
       %status = call i32 (i64) @usleep(i64 %usec)
       ret i32 %status
     }
@@ -372,7 +372,7 @@ sys 0m0.000s
     declare i32 @system(...)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i32 @main(i64 %jlstr) #0 {
+    define i32 @main(i64 %jlstr) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %status = call i32 (i8*, ...) bitcast (i32 (...)* @system to i32 (i8*, ...)*)(i8* %str)
       ret i32 %status
@@ -408,7 +408,7 @@ julia> strlen(c"foo")
     declare i64 @strlen(i8*)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main(i64 %jlstr) #0 {
+    define i64 @main(i64 %jlstr) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %li = call i64 (i8*) @strlen (i8* %str)
       ret i64 %li
@@ -450,7 +450,7 @@ end
     declare double @strtod(i8*, i8**)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local double @main(i64 %jlstr, i64 %jlp) #0 {
+    define double @main(i64 %jlstr, i64 %jlp) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %ptr = inttoptr i64 %jlp to i8**
       %d = call double (i8*, i8**) @strtod (i8* %str, i8** %ptr)
@@ -492,7 +492,7 @@ end
     declare i64 @strtol(i8*, i8**, i32)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
+    define i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %ptr = inttoptr i64 %jlp to i8**
       %li = call i64 (i8*, i8**, i32) @strtol (i8* %str, i8** %ptr, i32 %base)
@@ -534,7 +534,7 @@ end
     declare i64 @strtoul(i8*, i8**, i32)
 
     ; Function Attrs: nounwind ssp uwtable
-    define dso_local i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
+    define i64 @main(i64 %jlstr, i64 %jlp, i32 %base) #0 {
       %str = inttoptr i64 %jlstr to i8*
       %ptr = inttoptr i64 %jlp to i8**
       %li = call i64 (i8*, i8**, i32) @strtoul (i8* %str, i8** %ptr, i32 %base)

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -182,7 +182,8 @@ julia> a
     declare void @memset(i8* nocapture writeonly, i64, i64) #0
 
     ; Function Attrs: noinline nounwind ssp uwtable
-    define dso_local i32 @main(i8* %ptr, i64 %value, i64 %n) #1 {
+    define dso_local i32 @main(i64 %jlp, i64 %value, i64 %n) #1 {
+      %ptr = inttoptr i64 %jlp to i8*
       call void @memset(i8* %ptr, i64 %value, i64 %n)
       ret i32 0
     }
@@ -229,7 +230,9 @@ julia> a
     declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #0
 
     ; Function Attrs: noinline nounwind ssp uwtable
-    define dso_local i32 @main(i8* %dest, i8* %src, i64 %nbytes) #1 {
+    define dso_local i32 @main(i64 %jldest, i64 %jlsrc, i64 %nbytes) #1 {
+      %dest = inttoptr i64 %jldest to i8*
+      %src = inttoptr i64 %jlsrc to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dest, i8* %src, i64 %nbytes, i1 false)
       ret i32 0
     }
@@ -267,7 +270,9 @@ julia> memcmp(c"foo", c"bar", 3)
     declare i32 @memcmp(i8*, i8*, i64)
 
     ; Function Attrs: noinline nounwind ssp uwtable
-    define dso_local i32 @main(i8* %a, i8* %b, i64 %nbytes) #0 {
+    define dso_local i32 @main(i64 %jla, i64 %jlb, i64 %nbytes) #0 {
+      %a = inttoptr i64 %jla to i8*
+      %b = inttoptr i64 %jlb to i8*
       %cmp = call i32 @memcmp(i8* %a, i8* %b, i64 %nbytes)
       ret i32 %cmp
     }
@@ -367,8 +372,9 @@ sys 0m0.000s
     declare i32 @system(...)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i32 @main(i8* %str) #0 {
-      %1 = call i32 (i8*, ...) bitcast (i32 (...)* @system to i32 (i8*, ...)*)(i8* %str)
+    define dso_local i32 @main(i64 %jlstr) #0 {
+      %str = inttoptr i64 %jlstr to i8*
+      %status = call i32 (i8*, ...) bitcast (i32 (...)* @system to i32 (i8*, ...)*)(i8* %str)
       ret i32 0
     }
 
@@ -402,7 +408,8 @@ julia> strlen(c"foo")
     declare i64 @strlen(i8*)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i64 @main(i8* %str) #0 {
+    define dso_local i64 @main(i64 %jlstr) #0 {
+      %str = inttoptr i64 %jlstr to i8*
       %li = call i64 (i8*) @strlen (i8* %str)
       ret i64 %li
     }

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -24,9 +24,10 @@ julia> free(p)
     declare i8* @malloc(i64)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i8* @main(i64 %size) #0 {
+    define dso_local i64 @main(i64 %size) #0 {
       %ptr = call i8* (i64) @malloc(i64 %size)
-      ret i8* %ptr
+      %jlp = ptrtoint i8* %ptr to i64
+      ret i64 %jlp
     }
 
     attributes #0 = { noinline nounwind optnone ssp uwtable }
@@ -39,9 +40,10 @@ end
     declare i8* @malloc(i64)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i8* @main(i64 %size) #0 {
+    define dso_local i64 @main(i64 %size) #0 {
       %ptr = call i8* (i64) @malloc(i64 %size)
-      ret i8* %ptr
+      %jlp = ptrtoint i8* %ptr to i64
+      ret i64 %jlp
     }
 
     attributes #0 = { noinline nounwind optnone ssp uwtable }
@@ -90,9 +92,10 @@ julia> free(p)
     declare i8* @calloc(i64, i64)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i8* @main(i64 %n, i64 %size) #0 {
+    define dso_local i64 @main(i64 %n, i64 %size) #0 {
       %ptr = call i8* (i64, i64) @calloc(i64 %n, i64 %size)
-      ret i8* %ptr
+      %jlp = ptrtoint i8* %ptr to i64
+      ret i64 %jlp
     }
 
     attributes #0 = { noinline nounwind optnone ssp uwtable }
@@ -126,7 +129,8 @@ julia> free(p)
     declare void @free(i8*)
 
     ; Function Attrs: noinline nounwind optnone ssp uwtable
-    define dso_local i32 @main(i8* %ptr) #0 {
+    define dso_local i32 @main(i64 %jlp) #0 {
+      %ptr = inttoptr i64 %jlp to i8*
       call void (i8*) @free(i8* %ptr)
       ret i32 0
     }

--- a/src/printformats.jl
+++ b/src/printformats.jl
@@ -179,10 +179,14 @@ ERROR: could not do thing
     ; External declaration of the fprintf function
     declare i32 @fprintf(i8*, i8*)
 
-    define i32 @main(i8* %fp, i8* %str) {
+    define i32 @main(i64 %jlfp, i64 %jls) #0 {
     entry:
-        %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
-        ret i32 0
+      %fp = inttoptr i64 %jlfp to i8*
+      %str = inttoptr i64 %jls to i8*
+      %status = call i32 (i8*, i8*) @fprintf(i8* %fp, i8* %str)
+      ret i32 0
     }
+
+    attributes #0 = { alwaysinline nounwind ssp uwtable }
     """, "main"), Int32, Tuple{Ptr{FILE}, Ptr{UInt8}}, stderrp(), s)
 end

--- a/src/staticrng.jl
+++ b/src/staticrng.jl
@@ -140,11 +140,12 @@ julia> rand(rng) # Draw a `Float64` between 0 and 1
 @inline function xoshiro256✴︎✴︎(state::Ptr{UInt64})
     Base.llvmcall(("""
     ; Function Attrs: noinline nounwind ssp uwtable
-    define i64 @next(i64*) #0 {
+    define i64 @next(i64) #0 {
+      %ptr = inttoptr i64 %0 to i64*
       %2 = alloca i64*, align 8
       %3 = alloca i64, align 8
       %4 = alloca i64, align 8
-      store i64* %0, i64** %2, align 8
+      store i64* %ptr, i64** %2, align 8
       %5 = load i64*, i64** %2, align 8
       %6 = getelementptr inbounds i64, i64* %5, i64 1
       %7 = load i64, i64* %6, align 8


### PR DESCRIPTION
Julia pointers are LLVM ints, so technically we need to be converting back and forth with `inttoptr`/`ptrtoint` on the LLVM side before handing any pointers to Julia. These conversions should get optimized out anyways at the end of the day, but Julia 1.9 actually enforces correctness on this front even if you never do anything with that pointer on the native Julia side, and crashes if you ever omit the conversion.

It turns out fixing this was the only thing holding us back on Julia 1.9, so nightly tests should pass now (though note that StaticCompiler.jl itself doesn't support 1.9 yet, so you won't be able to do much with StaticTools there anyways at the moment)