### PR TITLE
`StackArray`s

### DIFF
--- a/src/StaticTools.jl
+++ b/src/StaticTools.jl
@@ -40,6 +40,7 @@ module StaticTools
     # Types
     export StaticString, MallocString, StringView, AbstractStaticString
     export MallocArray, MallocMatrix, MallocVector
+    export ArrayView
     # Macros
     export @c_str, @m_str, @mm_str
     export @ptrcall, @symbolcall

--- a/src/StaticTools.jl
+++ b/src/StaticTools.jl
@@ -11,8 +11,10 @@ module StaticTools
     struct FILE end # Plain struct to denote and dispatch on file pointers
     struct DYLIB end # Plain struct to denote and dispatch pointers to dlopen'd shlibs
 
-    # Arrays backed by malloc'd memory
-    include("mallocarray.jl")   # MallocArray, MallocMatrix, MallocVector
+    # Arrays backed by malloc'd and alloca'd memory
+    include("abstractstaticarray.jl")  # Shared array infrastructure
+    include("stackarray.jl")           # StackArray, StackMatrix, StackVector
+    include("mallocarray.jl")          # MallocArray, MallocMatrix, MallocVector
 
     # String handling
     include("abstractstaticstring.jl")  # Shared string infrastructure

--- a/src/StaticTools.jl
+++ b/src/StaticTools.jl
@@ -40,6 +40,7 @@ module StaticTools
     # Types
     export StaticString, MallocString, StringView, AbstractStaticString
     export MallocArray, MallocMatrix, MallocVector
+    export StackArray, StackMatrix, StackVector
     export ArrayView
     # Macros
     export @c_str, @m_str, @mm_str
@@ -48,6 +49,7 @@ module StaticTools
     # Functions
     export malloc, calloc, free, memset!, memcpy!, memcmp                       # Memory management
     export mfill, mzeros, mones, meye                                           # Other MallocArray functions
+    export sfill, szeros, sones, seye                                           # Other StackArray functions
     export stdinp, stdoutp, stderrp                                             # File pointers
     export fopen, fclose, ftell, frewind, fseek, SEEK_SET, SEEK_CUR, SEEK_END   # File open, close, seek
     export usleep                                                               # Other libc utility functions

--- a/src/abstractstaticarray.jl
+++ b/src/abstractstaticarray.jl
@@ -1,0 +1,134 @@
+
+    # General array interface
+
+    # Supertype for all arrays in this package
+    abstract type DenseStaticArray{T,N} <: DenseArray{T,N} end
+
+    # A subtype for arrays that are backed by a pointer, length, and size alone
+    abstract type DensePointerArray{T,N} <: DenseStaticArray{T,N} end
+
+    # Lightweight type for taking a view into an existing array
+    struct ArrayView{T,N} <: DensePointerArray{T,N}
+        pointer::Ptr{T}
+        length::Int
+        size::NTuple{N, Int}
+    end
+
+
+    # Fundamentals
+    @inline Base.unsafe_convert(::Type{Ptr{T}}, a::DensePointerArray) where {T} = Ptr{T}(a.pointer)
+    @inline Base.pointer(a::DensePointerArray) = a.pointer
+    @inline Base.length(a::DensePointerArray) = a.length
+    @inline Base.sizeof(a::DensePointerArray{T}) where {T} = a.length * sizeof(T)
+    @inline Base.size(a::DensePointerArray) = a.size
+
+
+    # Some of the AbstractArray interface:
+    @inline Base.IndexStyle(::DenseStaticArray) = IndexLinear()
+    @inline Base.stride(a::DenseStaticArray, dim::Int) = (dim <= 1) ? 1 : stride(a, dim-1) * size(a, dim-1)
+    @inline Base.firstindex(::DenseStaticArray) = 1
+    @inline Base.lastindex(a::DenseStaticArray) = length(a)
+
+    # Scalar getindex
+    @inline Base.getindex(a::DenseStaticArray{T,0}) where {T} = unsafe_load(pointer(a))
+    @inline Base.getindex(a::DenseStaticArray{T}, i::Int) where T = unsafe_load(pointer(a)+(i-1)*sizeof(T))
+
+    # Getindex methods returning views
+    @inline Base.getindex(a::DenseStaticArray, ::Colon) = a
+    @inline Base.getindex(a::DenseStaticArray{T}, r::UnitRange{<:Integer}) where T = ArrayView(pointer(a)+(first(r)-1)*sizeof(T), length(r), (length(r),))
+    @inline Base.getindex(a::DenseStaticArray, r::UnitRange{<:Integer}, inds::Vararg{Int}) = getindex(a, r, inds)
+    @inline function Base.getindex(a::DenseStaticArray{T}, r::UnitRange{<:Integer}, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+1)
+        end
+        return ArrayView{T,1}(pointer(a)+i0*sizeof(T), length(r), (length(r),))
+    end
+    @inline Base.getindex(a::DenseStaticArray, ::Colon, inds::Vararg{Int}) = getindex(a, :, inds)
+    @inline function Base.getindex(a::DenseStaticArray{T}, ::Colon, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+1)
+        end
+        return ArrayView{T,1}(pointer(a)+i0*sizeof(T), size(a,1), (size(a,1),))
+    end
+    @inline Base.getindex(a::DenseStaticArray, ::Colon, ::Colon, inds::Vararg{Int}) = getindex(a, :, :, inds)
+    @inline function Base.getindex(a::DenseStaticArray{T}, ::Colon, ::Colon, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+2)
+        end
+        return ArrayView{T,2}(pointer(a)+i0*sizeof(T), size(a,1)*size(a,2), (size(a,1), size(a,2)))
+    end
+    @inline Base.getindex(a::DenseStaticArray, ::Colon, ::Colon, ::Colon, inds::Vararg{Int}) = getindex(a, :, :, :, inds)
+    @inline function Base.getindex(a::DenseStaticArray{T}, ::Colon, ::Colon, ::Colon, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+3)
+        end
+        return ArrayView{T,3}(pointer(a)+i0*sizeof(T), size(a,1)*size(a,2)*size(a,3), (size(a,1), size(a,2), size(a,3)))
+    end
+
+    # Setindex methods
+    @inline Base.setindex!(a::DenseStaticArray{T,0}, x::T) where {T} = unsafe_store!(pointer(a), x)
+    @inline Base.setindex!(a::DenseStaticArray{T,0}, x) where {T} = unsafe_store!(pointer(a), convert(T,x))
+    @inline Base.setindex!(a::DenseStaticArray{T}, x::T, i::Int) where {T} = unsafe_store!(pointer(a)+(i-1)*sizeof(T), x)
+    @inline Base.setindex!(a::DenseStaticArray{T}, x, i::Int) where {T} = unsafe_store!(pointer(a)+(i-1)*sizeof(T), convert(T,x))
+    @inline function Base.setindex!(a::DenseStaticArray{T}, x::Union{AbstractArray{T},NTuple{T}}, r::UnitRange{Int}) where T
+        ix₀ = firstindex(x)-first(r)
+        for i ∈ r
+            setindex!(a, x[i+ix₀], i)
+        end
+    end
+    @inline function Base.setindex!(a::DenseStaticArray{T}, x::T, r::UnitRange{Int}) where T
+        for i ∈ r
+            setindex!(a, x, i)
+        end
+    end
+    @inline function Base.setindex!(a::DenseStaticArray{T}, x::Union{AbstractArray{T},NTuple{T}}, ::Colon) where T
+        ix₀ = firstindex(x)-1
+        for i ∈ eachindex(a)
+            setindex!(a, x[i+ix₀], i)
+        end
+    end
+    @inline function Base.setindex!(a::DenseStaticArray{T}, x::T, ::Colon) where T
+        for i ∈ eachindex(a)
+            setindex!(a, x, i)
+        end
+    end
+
+    # Other nice functions
+    @inline Base.fill!(A::DenseStaticArray{T}, x) where {T} = fill!(A, convert(T,x))
+    @inline function Base.fill!(A::DenseStaticArray{T}, x::T) where {T}
+        setindex!(A, x, :)
+        return A
+    end
+
+    @inline function Base.:(==)(a::DenseStaticArray{A}, b::DenseStaticArray{B}) where {A,B}
+        (N = length(a)) == length(b) || return false
+        pa, pb = pointer(a), pointer(b)
+        for n in 0:N-1
+            unsafe_load(pa + n*sizeof(A)) == unsafe_load(pb + n*sizeof(B)) || return false
+        end
+        return true
+    end
+    @inline function Base.:(==)(a::DenseStaticArray, b::NTuple{N, <:Number}) where N
+        N == length(a) || return false
+        for n in 1:N
+            a[n] == b[n] || return false
+        end
+        return true
+    end
+    @inline function Base.:(==)(a::NTuple{N, <:Number}, b::DenseStaticArray) where N
+        N == length(b) || return false
+        for n in 1:N
+            a[n] == b[n] || return false
+        end
+        return true
+    end
+
+    # Custom printing
+    @inline Base.print(a::DenseStaticArray) = printf(a)
+    @inline Base.println(a::DenseStaticArray) = (printf(a); newline())
+    @inline Base.print(fp::Ptr{FILE}, a::DenseStaticArray) = printf(fp, a)
+    @inline Base.println(fp::Ptr{FILE}, a::DenseStaticArray) = (printf(fp, a); newline(fp))

--- a/src/abstractstaticarray.jl
+++ b/src/abstractstaticarray.jl
@@ -104,24 +104,25 @@
         return A
     end
 
-    @inline function Base.:(==)(a::DenseStaticArray{A}, b::DenseStaticArray{B}) where {A,B}
+    @inline function Base.:(==)(a::DenseStaticArray{Ta}, b::DenseStaticArray{Tb}) where {Ta,Tb}
         (N = length(a)) == length(b) || return false
         pa, pb = pointer(a), pointer(b)
+        sa, sb = sizeof(Ta), sizeof(Tb)
         for n in 0:N-1
-            unsafe_load(pa + n*sizeof(A)) == unsafe_load(pb + n*sizeof(B)) || return false
+            unsafe_load(pa + n*sa) == unsafe_load(pb + n*sb) || return false
         end
         return true
     end
-    @inline function Base.:(==)(a::DenseStaticArray, b::NTuple{N, <:Number}) where N
-        N == length(a) || return false
-        for n in 1:N
+    @inline function Base.:(==)(a::DenseStaticArray, b::Union{DenseArray,NTuple})
+        length(a) == length(b) || return false
+        @inbounds for n in eachindex(a)
             a[n] == b[n] || return false
         end
         return true
     end
-    @inline function Base.:(==)(a::NTuple{N, <:Number}, b::DenseStaticArray) where N
-        N == length(b) || return false
-        for n in 1:N
+    @inline function Base.:(==)(a::Union{DenseArray,NTuple}, b::DenseStaticArray)
+        length(a) == length(b) || return false
+        @inbounds for n in eachindex(b)
             a[n] == b[n] || return false
         end
         return true

--- a/src/mallocarray.jl
+++ b/src/mallocarray.jl
@@ -100,21 +100,20 @@
     @inline MallocArray{T,N}(x::PointerOrInitializer, dims::Vararg{Int}) where {T,N} = MallocArray{T,N}(x, prod(dims), dims)
     @inline MallocArray{T}(x::PointerOrInitializer, dims::Vararg{Int}) where {T} = MallocArray{T}(x, dims)
 
+    # Destructor:
+    @inline free(a::MallocArray) = free(a.pointer)
+
     # Indirect constructors
     @inline Base.similar(a::MallocArray{T,N}) where {T,N} = MallocArray{T,N}(undef, size(a))
     @inline Base.similar(a::MallocArray{T}, dims::Dims{N}) where {T,N} = MallocArray{T,N}(undef, dims)
-    @inline Base.similar(a::MallocArray{T}, dims::Vararg{Int}) where {T} = MallocArray{T}(undef, dims)
+    @inline Base.similar(a::MallocArray, dims::Vararg{Int}) = similar(a, dims)
     @inline Base.similar(a::MallocArray, ::Type{T}, dims::Dims{N}) where {T,N} = MallocArray{T,N}(undef, dims)
-    @inline Base.similar(a::MallocArray, ::Type{T}, dims::Vararg{Int}) where {T} = MallocArray{T}(undef, dims)
+    @inline Base.similar(a::MallocArray, T::Type, dims::Vararg{Int}) = similar(a, T, dims)
     @inline function Base.copy(a::MallocArray{T,N}) where {T,N}
         c = MallocArray{T,N}(undef, size(a))
         copyto!(c, a)
         return c
     end
-
-    # Destructor:
-    @inline free(a::MallocArray) = free(a.pointer)
-
 
     # Other custom constructors
     """

--- a/src/mallocarray.jl
+++ b/src/mallocarray.jl
@@ -13,7 +13,7 @@
     StaticCompiler-safe, (2) should be `free`d when no longer in use, and
     (3) indexing returns views rather than copies.
     """
-    struct MallocArray{T,N} <: DenseArray{T,N}
+    struct MallocArray{T,N} <: DensePointerArray{T,N}
         pointer::Ptr{T}
         length::Int
         size::NTuple{N, Int}
@@ -107,121 +107,14 @@
     @inline Base.similar(a::MallocArray, ::Type{T}, dims::Dims{N}) where {T,N} = MallocArray{T,N}(undef, dims)
     @inline Base.similar(a::MallocArray, ::Type{T}, dims::Vararg{Int}) where {T} = MallocArray{T}(undef, dims)
     @inline function Base.copy(a::MallocArray{T,N}) where {T,N}
-        new_a = MallocArray{T,N}(undef, size(a))
-        copyto!(new_a, a)
-        return new_a
+        c = MallocArray{T,N}(undef, size(a))
+        copyto!(c, a)
+        return c
     end
 
     # Destructor:
     @inline free(a::MallocArray) = free(a.pointer)
 
-    # Fundamentals
-    @inline Base.unsafe_convert(::Type{Ptr{T}}, a::MallocArray) where {T} = Ptr{T}(a.pointer)
-    @inline Base.pointer(a::MallocArray) = a.pointer
-    @inline Base.length(a::MallocArray) = a.length
-    @inline Base.sizeof(a::MallocArray{T}) where {T} = a.length * sizeof(T)
-    @inline Base.size(a::MallocArray) = a.size
-
-    # Some of the AbstractArray interface:
-    @inline Base.IndexStyle(::MallocArray) = IndexLinear()
-    @inline Base.stride(a::MallocArray, dim::Int) = (dim <= 1) ? 1 : stride(a, dim-1) * size(a, dim-1)
-    @inline Base.firstindex(::MallocArray) = 1
-    @inline Base.lastindex(a::MallocArray) = a.length
-    @inline Base.getindex(a::MallocArray{T,0}) where {T} = unsafe_load(pointer(a))
-    @inline Base.getindex(a::MallocArray{T}, i::Int) where T = unsafe_load(pointer(a)+(i-1)*sizeof(T))
-    @inline Base.getindex(a::MallocArray, ::Colon) = a
-    @inline Base.getindex(a::MallocArray{T}, r::UnitRange{<:Integer}) where T = MallocArray(pointer(a)+(first(r)-1)*sizeof(T), length(r), (length(r),))
-
-    @inline Base.getindex(a::MallocArray, r::UnitRange{<:Integer}, inds::Vararg{Int}) = getindex(a, r, inds)
-    @inline function Base.getindex(a::MallocArray{T}, r::UnitRange{<:Integer}, inds::Dims{N}) where {T,N}
-        i0 = 0
-        for i=1:N
-            i0 += (inds[i]-1) * stride(a, i+1)
-        end
-        return MallocArray{T,1}(pointer(a)+i0*sizeof(T), length(r), (length(r),))
-    end
-
-    @inline Base.getindex(a::MallocArray, ::Colon, inds::Vararg{Int}) = getindex(a, :, inds)
-    @inline function Base.getindex(a::MallocArray{T}, ::Colon, inds::Dims{N}) where {T,N}
-        i0 = 0
-        for i=1:N
-            i0 += (inds[i]-1) * stride(a, i+1)
-        end
-        return MallocArray{T,1}(pointer(a)+i0*sizeof(T), size(a,1), (size(a,1),))
-    end
-    @inline Base.getindex(a::MallocArray, ::Colon, ::Colon, inds::Vararg{Int}) = getindex(a, :, :, inds)
-    @inline function Base.getindex(a::MallocArray{T}, ::Colon, ::Colon, inds::Dims{N}) where {T,N}
-        i0 = 0
-        for i=1:N
-            i0 += (inds[i]-1) * stride(a, i+2)
-        end
-        return MallocArray{T,2}(pointer(a)+i0*sizeof(T), size(a,1)*size(a,2), (size(a,1), size(a,2)))
-    end
-    @inline Base.getindex(a::MallocArray, ::Colon, ::Colon, ::Colon, inds::Vararg{Int}) = getindex(a, :, :, :, inds)
-    @inline function Base.getindex(a::MallocArray{T}, ::Colon, ::Colon, ::Colon, inds::Dims{N}) where {T,N}
-        i0 = 0
-        for i=1:N
-            i0 += (inds[i]-1) * stride(a, i+3)
-        end
-        return MallocArray{T,3}(pointer(a)+i0*sizeof(T), size(a,1)*size(a,2)*size(a,3), (size(a,1), size(a,2), size(a,3)))
-    end
-
-    @inline Base.setindex!(a::MallocArray{T,0}, x::T) where {T} = unsafe_store!(pointer(a), x)
-    @inline Base.setindex!(a::MallocArray{T,0}, x) where {T} = unsafe_store!(pointer(a), convert(T,x))
-    @inline Base.setindex!(a::MallocArray{T}, x::T, i::Int) where {T} = unsafe_store!(pointer(a)+(i-1)*sizeof(T), x)
-    @inline Base.setindex!(a::MallocArray{T}, x, i::Int) where {T} = unsafe_store!(pointer(a)+(i-1)*sizeof(T), convert(T,x))
-    @inline function Base.setindex!(a::MallocArray{T}, x::Union{AbstractArray{T},NTuple{T}}, r::UnitRange{Int}) where T
-        ix₀ = firstindex(x)-first(r)
-        @inbounds for i ∈ r
-            setindex!(a, x[i+ix₀], i)
-        end
-    end
-    @inline function Base.setindex!(a::MallocArray{T}, x::T, r::UnitRange{Int}) where T
-        @inbounds for i ∈ r
-            setindex!(a, x, i)
-        end
-    end
-    @inline function Base.setindex!(a::MallocArray{T}, x::Union{AbstractArray{T},NTuple{T}}, ::Colon) where T
-        ix₀ = firstindex(x)-1
-        @inbounds for i ∈ eachindex(a)
-            setindex!(a, x[i+ix₀], i)
-        end
-    end
-    @inline function Base.setindex!(a::MallocArray{T}, x::T, ::Colon) where T
-        @inbounds for i ∈ eachindex(a)
-            setindex!(a, x, i)
-        end
-    end
-
-    # Other nice functions
-    @inline Base.fill!(A::MallocArray{T}, x) where {T} = fill!(A, convert(T,x))
-    @inline function Base.fill!(A::MallocArray{T}, x::T) where {T}
-        setindex!(A, x, :)
-        return A
-    end
-
-    @inline function Base.:(==)(a::MallocArray{A}, b::MallocArray{B}) where {A,B}
-        (N = length(a)) == length(b) || return false
-        pa, pb = pointer(a), pointer(b)
-        for n in 0:N-1
-            unsafe_load(pa + n*sizeof(A)) == unsafe_load(pb + n*sizeof(B)) || return false
-        end
-        return true
-    end
-    @inline function Base.:(==)(a::MallocArray, b::NTuple{N, <:Number}) where N
-        N == length(a) || return false
-        for n in 1:N
-            a[n] == b[n] || return false
-        end
-        return true
-    end
-    @inline function Base.:(==)(a::NTuple{N, <:Number}, b::MallocArray) where N
-        N == length(b) || return false
-        for n in 1:N
-            a[n] == b[n] || return false
-        end
-        return true
-    end
 
     # Reshaping and Reinterpreting
     @inline function Base.reshape(a::MallocArray{T}, dims::Dims{N})  where {T,N}
@@ -239,12 +132,6 @@
         pointerᵣ = Ptr{Tᵣ}(pointer(a))
         MallocArray{Tᵣ,N}(pointerᵣ, lengthᵣ, sizeᵣ)
     end
-
-    # Custom printing
-    @inline Base.print(a::MallocArray) = printf(a)
-    @inline Base.println(a::MallocArray) = (printf(a); newline())
-    @inline Base.print(fp::Ptr{FILE}, a::MallocArray) = printf(fp, a)
-    @inline Base.println(fp::Ptr{FILE}, a::MallocArray) = (printf(fp, a); newline(fp))
 
 
     # Other custom constructors

--- a/src/mallocarray.jl
+++ b/src/mallocarray.jl
@@ -116,24 +116,6 @@
     @inline free(a::MallocArray) = free(a.pointer)
 
 
-    # Reshaping and Reinterpreting
-    @inline function Base.reshape(a::MallocArray{T}, dims::Dims{N})  where {T,N}
-        @assert prod(dims) == length(a)
-        MallocArray{T,N}(pointer(a), dims)
-    end
-    @inline Base.reshape(a::MallocArray, dims::Vararg{Int}) = reshape(a, dims)
-
-    @inline function Base.reinterpret(::Type{Tᵣ}, a::MallocArray{Tᵢ,N}) where {N,Tᵣ,Tᵢ}
-        @assert Base.allocatedinline(Tᵣ)
-        @assert length(a)*sizeof(Tᵢ) % sizeof(Tᵣ) == 0
-        @assert size(a,1)*sizeof(Tᵢ) % sizeof(Tᵣ) == 0
-        lengthᵣ = length(a)*sizeof(Tᵢ)÷sizeof(Tᵣ)
-        sizeᵣ = ntuple(i -> i==1 ? size(a,i)*sizeof(Tᵢ)÷sizeof(Tᵣ) : size(a,i), Val(N))
-        pointerᵣ = Ptr{Tᵣ}(pointer(a))
-        MallocArray{Tᵣ,N}(pointerᵣ, lengthᵣ, sizeᵣ)
-    end
-
-
     # Other custom constructors
     """
     ```julia

--- a/src/stackarray.jl
+++ b/src/stackarray.jl
@@ -1,0 +1,320 @@
+
+    # Definition and constructors:
+    """
+    ```julia
+    StackArray{T,N} <: AbstractArray{T,N}
+    ```
+    `N`-dimensional dense stack-allocated array with elements of type `T`.
+
+    Much like `Base.Array`, except (1) backed by memory that is not tracked by
+    the Julia garbage collector (is stack allocated by `alloca`), so is
+    StaticCompiler-friendly, and (2) indexing returns views rather than copies.
+    """
+    mutable struct StackArray{T,N,L,D} <: DenseArray{T,N}
+        data::NTuple{L,T}
+        @inline function StackArray{T,N,L,D}(::UndefInitializer) where {T,N,L,D}
+            @assert Base.allocatedinline(T)
+            @assert N == length(D)
+            @assert L == prod(D)
+            A = new{T,N,L,D}()
+        end
+        @inline function StackArray{T,N}(::UndefInitializer, size::Dims{N}) where {T,N}
+            @assert Base.allocatedinline(T)
+            L = prod(size)
+            A = new{T,N,L,size}()
+        end
+        @inline function StackArray{T,N}(data::NTuple{L,T₀}, size::Dims{N}) where {T,N,L,T₀}
+            @assert Base.allocatedinline(T)
+            @assert prod(size)*sizeof(T) == L*sizeof(T₀)
+            A = new{T,N,prod(size),size}()
+        end
+        @inline function StackArray(data::NTuple{L,T}, size::Dims{N}) where {T,N,L}
+            @assert Base.allocatedinline(T)
+            @assert L == prod(size)
+            A = new{T,N,L,size}()
+        end
+    end
+
+
+    """
+    ```julia
+    StackMatrix{T} <: AbstractMatrix{T}
+    ```
+    Two-dimensional dense stack-allocated array with elements of type `T`.
+    As `Base.Matrix` is to `Base.Array`, but with `StackArray`.
+    """
+    const StackMatrix{T,L,D} = StackArray{T,2,L,D}
+    """
+    ```julia
+    StackVector{T} <: AbstractVector{T}
+    ```
+    Two-dimensional dense stack-allocated array with elements of type `T`.
+    As `Base.Vector` is to `Base.Array`, but with `StackArray`.
+    """
+    const StackVector{T,L,D} = StackArray{T,1,L,D}
+
+
+    """
+    ```julia
+    StackArray{T}(undef, dims)
+    StackArray{T,N}(undef, dims)
+    ```
+    Construct an uninitialized `N`-dimensional `StackArray` containing elements
+    of type `T`. `N` can either be supplied explicitly, as in `Array{T,N}(undef, dims)`,
+    or be determined by the length or number of `dims`. `dims` may be a tuple or
+    a series of integer arguments corresponding to the lengths in each dimension.
+    If the rank `N` is supplied explicitly, then it must match the length or
+    number of `dims`.
+
+    ## Examples
+    ```julia
+    julia> A = StackArray{Float64}(undef, 3,3) # implicit N
+    3×3 StackMatrix{Float64}:
+     3.10504e231   6.95015e-310   2.12358e-314
+     1.73061e-77   6.95015e-310   5.56271e-309
+     6.95015e-310  0.0           -1.29074e-231
+    ```
+    """
+    @inline StackArray(x::NTuple, dims::Vararg{Int}) = StackArray(x, dims)
+    @inline StackArray{T}(x::Union{UndefInitializer,NTuple}, dims::Vararg{Int}) where {T} = StackArray{T}(x, dims)
+    @inline StackArray{T}(x::Union{UndefInitializer,NTuple}, dims::Dims{N}) where {T,N} = StackArray{T,N}(x, dims)
+    @inline StackArray{T,N}(x::Union{UndefInitializer,NTuple}, dims::Vararg{Int}) where {T,N} = StackArray{T,N}(x, dims)
+
+
+    # Indirect constructors
+    @inline Base.similar(a::StackArray{T,N,L,D}) where {T,N,L,D} = StackArray{T,N,L,D}(undef)
+    @inline Base.similar(a::StackArray{T}, dims::Dims{N}) where {T,N} = StackArray{T,N}(undef, dims)
+    @inline Base.similar(a::StackArray{T}, dims::Vararg{Int}) where {T} = StackArray{T}(undef, dims)
+    @inline Base.similar(a::StackArray, ::Type{T}, dims::Dims{N}) where {T,N} = StackArray{T,N}(undef, dims)
+    @inline Base.similar(a::StackArray, ::Type{T}, dims::Vararg{Int}) where {T} = StackArray{T}(undef, dims)
+    @inline function Base.copy(a::StackArray{T,N,L,D}) where {T,N,L,D}
+        c = StackArray{T,N,L,D}(undef)
+        copyto!(c, a)
+        return c
+    end
+
+    # Fundamentals
+    @inline Base.unsafe_convert(::Type{Ptr{T}}, a::StackArray) where {T} = Ptr{T}(pointer_from_objref(a))
+    @inline Base.pointer(a::StackArray{T}) where {T} = Ptr{T}(pointer_from_objref(a))
+    @inline Base.length(a::StackArray{T,N,L}) where {T,N,L} = L
+    @inline Base.sizeof(a::StackArray{T,N,L}) where {T,N,L} = L * sizeof(T)
+    @inline Base.size(a::StackArray{T,N,L,D}) where {T,N,L,D} = D
+
+    # Some of the AbstractArray interface:
+    @inline Base.IndexStyle(::StackArray) = IndexLinear()
+    @inline Base.stride(a::StackArray, dim::Int) = (dim <= 1) ? 1 : stride(a, dim-1) * size(a, dim-1)
+    @inline Base.firstindex(::StackArray) = 1
+    @inline Base.lastindex(a::StackArray) = a.length
+    @inline Base.getindex(a::StackArray{T,0}) where {T} = unsafe_load(pointer(a))
+    @inline Base.getindex(a::StackArray{T}, i::Int) where T = unsafe_load(pointer(a)+(i-1)*sizeof(T))
+    @inline Base.getindex(a::StackArray, ::Colon) = a
+    @inline Base.getindex(a::StackArray{T}, r::UnitRange{<:Integer}) where T = StackArray(pointer(a)+(first(r)-1)*sizeof(T), length(r), (length(r),))
+
+    @inline Base.getindex(a::StackArray, r::UnitRange{<:Integer}, inds::Vararg{Int}) = getindex(a, r, inds)
+    @inline function Base.getindex(a::StackArray{T}, r::UnitRange{<:Integer}, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+1)
+        end
+        return StackArray{T,1}(pointer(a)+i0*sizeof(T), length(r), (length(r),))
+    end
+
+    @inline Base.getindex(a::StackArray, ::Colon, inds::Vararg{Int}) = getindex(a, :, inds)
+    @inline function Base.getindex(a::StackArray{T}, ::Colon, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+1)
+        end
+        return StackArray{T,1}(pointer(a)+i0*sizeof(T), size(a,1), (size(a,1),))
+    end
+    @inline Base.getindex(a::StackArray, ::Colon, ::Colon, inds::Vararg{Int}) = getindex(a, :, :, inds)
+    @inline function Base.getindex(a::StackArray{T}, ::Colon, ::Colon, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+2)
+        end
+        return StackArray{T,2}(pointer(a)+i0*sizeof(T), size(a,1)*size(a,2), (size(a,1), size(a,2)))
+    end
+    @inline Base.getindex(a::StackArray, ::Colon, ::Colon, ::Colon, inds::Vararg{Int}) = getindex(a, :, :, :, inds)
+    @inline function Base.getindex(a::StackArray{T}, ::Colon, ::Colon, ::Colon, inds::Dims{N}) where {T,N}
+        i0 = 0
+        for i=1:N
+            i0 += (inds[i]-1) * stride(a, i+3)
+        end
+        return StackArray{T,3}(pointer(a)+i0*sizeof(T), size(a,1)*size(a,2)*size(a,3), (size(a,1), size(a,2), size(a,3)))
+    end
+
+    @inline Base.setindex!(a::StackArray{T,0}, x::T) where {T} = unsafe_store!(pointer(a), x)
+    @inline Base.setindex!(a::StackArray{T,0}, x) where {T} = unsafe_store!(pointer(a), convert(T,x))
+    @inline Base.setindex!(a::StackArray{T}, x::T, i::Int) where {T} = unsafe_store!(pointer(a)+(i-1)*sizeof(T), x)
+    @inline Base.setindex!(a::StackArray{T}, x, i::Int) where {T} = unsafe_store!(pointer(a)+(i-1)*sizeof(T), convert(T,x))
+    @inline function Base.setindex!(a::StackArray{T}, x::Union{AbstractArray{T},NTuple{T}}, r::UnitRange{Int}) where T
+        ix₀ = firstindex(x)-first(r)
+        @inbounds for i ∈ r
+            setindex!(a, x[i+ix₀], i)
+        end
+    end
+    @inline function Base.setindex!(a::StackArray{T}, x::T, r::UnitRange{Int}) where T
+        @inbounds for i ∈ r
+            setindex!(a, x, i)
+        end
+    end
+    @inline function Base.setindex!(a::StackArray{T}, x::Union{AbstractArray{T},NTuple{T}}, ::Colon) where T
+        ix₀ = firstindex(x)-1
+        @inbounds for i ∈ eachindex(a)
+            setindex!(a, x[i+ix₀], i)
+        end
+    end
+    @inline function Base.setindex!(a::StackArray{T}, x::T, ::Colon) where T
+        @inbounds for i ∈ eachindex(a)
+            setindex!(a, x, i)
+        end
+    end
+
+    # Other nice functions
+    @inline Base.fill!(A::StackArray{T}, x) where {T} = fill!(A, convert(T,x))
+    @inline function Base.fill!(A::StackArray{T}, x::T) where {T}
+        setindex!(A, x, :)
+        return A
+    end
+
+    @inline function Base.:(==)(a::StackArray{A}, b::StackArray{B}) where {A,B}
+        (N = length(a)) == length(b) || return false
+        pa, pb = pointer(a), pointer(b)
+        for n in 0:N-1
+            unsafe_load(pa + n*sizeof(A)) == unsafe_load(pb + n*sizeof(B)) || return false
+        end
+        return true
+    end
+    @inline function Base.:(==)(a::StackArray, b::NTuple{N, <:Number}) where N
+        N == length(a) || return false
+        for n in 1:N
+            a[n] == b[n] || return false
+        end
+        return true
+    end
+    @inline function Base.:(==)(a::NTuple{N, <:Number}, b::StackArray) where N
+        N == length(b) || return false
+        for n in 1:N
+            a[n] == b[n] || return false
+        end
+        return true
+    end
+
+    # Reshaping and Reinterpreting
+    @inline function Base.reshape(a::StackArray{T}, dims::Dims{N})  where {T,N}
+        @assert prod(dims) == length(a)
+        StackArray{T,N}(pointer(a), dims)
+    end
+    @inline Base.reshape(a::StackArray, dims::Vararg{Int}) = reshape(a, dims)
+
+    @inline function Base.reinterpret(::Type{Tᵣ}, a::StackArray{Tᵢ,N}) where {N,Tᵣ,Tᵢ}
+        @assert Base.allocatedinline(Tᵣ)
+        @assert length(a)*sizeof(Tᵢ) % sizeof(Tᵣ) == 0
+        @assert size(a,1)*sizeof(Tᵢ) % sizeof(Tᵣ) == 0
+        lengthᵣ = length(a)*sizeof(Tᵢ)÷sizeof(Tᵣ)
+        sizeᵣ = ntuple(i -> i==1 ? size(a,i)*sizeof(Tᵢ)÷sizeof(Tᵣ) : size(a,i), Val(N))
+        pointerᵣ = Ptr{Tᵣ}(pointer(a))
+        StackArray{Tᵣ,N}(pointerᵣ, lengthᵣ, sizeᵣ)
+    end
+
+
+    # Other custom constructors
+    """
+    ```julia
+    szeros([T=Float64,] dims::Tuple)
+    szeros([T=Float64,] dims...)
+    ```
+    Create a `StackArray{T}` containing all zeros of type `T`, of size `dims`.
+    As `Base.zeros`, but returning a `StackArray` instead of an `Array`.
+
+    See also `sones`, `sfill`.
+
+    ## Examples
+    ```julia
+    julia> szeros(Int32, 2,2)
+    2×2 StackMatrix{Int32}:
+     0  0
+     0  0
+    ```
+    """
+    @inline szeros(dims::Vararg{Int}) = szeros(dims)
+    @inline szeros(dims::Dims{N}) where {N} = fill!(StackArray{Float64,N}(undef, dims), 0.0)
+    @inline szeros(T::Type, dims::Vararg{Int}) = szeros(T, dims)
+    @inline szeros(::Type{T}, dims::Dims{N}) where {T,N} = fill!(StackArray{T,N}(undef, dims), zero(T))
+
+    """
+    ```julia
+    sones([T=Float64,] dims::Tuple)
+    sones([T=Float64,] dims...)
+    ```
+    Create a `StackArray{T}` containing all zeros of type `T`, of size `dims`.
+    As `Base.zeros`, but returning a `StackArray` instead of an `Array`.
+
+    See also `szeros`, `sfill`.
+
+    ## Examples
+    ```julia
+    julia> sones(Int32, 2,2)
+    2×2 StackMatrix{Int32}:
+     1  1
+     1  1
+    ```
+    """
+    @inline sones(dims::Vararg{Int}) = sones(Float64, dims)
+    @inline sones(dims::Dims) = sones(Float64, dims)
+    @inline sones(T::Type, dims::Vararg{Int}) = sones(T, dims)
+    @inline function sones(::Type{T}, dims::Dims{N}) where {T,N}
+        A = StackArray{T,N}(undef, dims)
+        fill!(A, one(T))
+    end
+
+    """
+    ```julia
+    seye([T=Float64,] dim::Int)
+    ```
+    Create a `StackArray{T}` containing an identity matrix of type `T`,
+    of size `dim` x `dim`.
+
+    ## Examples
+    ```julia
+    julia> seye(Int32, 2,2)
+    2×2 StackMatrix{Int32}:
+     1  0
+     0  1
+    ```
+    """
+    @inline seye(dim::Int) = seye(Float64, dim)
+    @inline function seye(::Type{T}, dim::Int) where {T}
+        A = StackMatrix{T,dim*dim,(dim,dim)}(undef)
+        fill!(A, zero(T))
+        𝔦 = one(T)
+        @inbounds for i=1:dim
+            A[i,i] = 𝔦
+        end
+        return A
+    end
+
+    """
+    ```julia
+    sfill(x::T, dims::Tuple)
+    sfill(x::T, dims...)
+    ```
+    Create a `StackArray{T}` of size `dims`, filled with the value `x`, where `x` is of type `T`.
+    As `Base.fill`, but returning a `StackArray` instead of an `Array`.
+
+    See also `szeros`, `sones`.
+
+    ## Examples
+    ```julia
+    julia> sfill(3, 2, 2)
+    2×2 StackMatrix{Int64}:
+     3  3
+     3  3
+    ```
+    """
+    @inline sfill(x, dims::Vararg{Int}) = sfill(x, dims)
+    @inline function sfill(x::T, dims::Dims{N}) where {T,N}
+        A = StackArray{T,N,prod(dims),dims}(undef)
+        fill!(A, x)
+    end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ const GROUP = get(ENV, "GROUP", "All")
     @testset "StaticString" begin include("teststaticstring.jl") end
     @testset "MallocString" begin include("testmallocstring.jl") end
     @testset "MallocArray" begin include("testmallocarray.jl") end
+    @testset "StackArray" begin include("teststackarray.jl") end
     @testset "StaticRNG" begin include("teststaticrng.jl") end
 end
 

--- a/test/scripts/loopvec_matrix_stack.jl
+++ b/test/scripts/loopvec_matrix_stack.jl
@@ -1,0 +1,49 @@
+using StaticCompiler
+using StaticTools
+using LoopVectorization
+
+@inline function mul!(C::StackArray, A::StackArray, B::StackArray)
+    @turbo for n ∈ indices((C,B), 2), m ∈ indices((C,A), 1)
+        Cmn = zero(eltype(C))
+        for k ∈ indices((A,B), (2,1))
+            Cmn += A[m,k] * B[k,n]
+        end
+        C[m,n] = Cmn
+    end
+    return C
+end
+
+function loopvec_matrix_stack()
+    rows = 10
+    cols = 5
+
+    # LHS
+    A = StackArray{Float64}(undef, rows, cols)
+    @turbo for i ∈ axes(A, 1)
+        for j ∈ axes(A, 2)
+           A[i,j] = i*j
+        end
+    end
+
+    # RHS
+    B = StackArray{Float64}(undef, cols, rows)
+    @turbo for i ∈ axes(B, 1)
+        for j ∈ axes(B, 2)
+           B[i,j] = i*j
+        end
+    end
+
+    # # Matrix multiplication
+    C = StackArray{Float64}(undef, cols, cols)
+    mul!(C, B, A)
+
+    # Print to stdout
+    printf(C)
+    # Also print to file
+    fp = fopen(c"table.tsv",c"w")
+    printf(fp, C)
+    fclose(fp)
+end
+
+# Attempt to compile
+path = compile_executable(loopvec_matrix_stack, (), "./")

--- a/test/testmallocarray.jl
+++ b/test/testmallocarray.jl
@@ -22,10 +22,11 @@
     @test A[10] === 2.0
     A[:] = ones(20)
     @test A[8] === 1.0
-    @test A === A[1:end]
+    @test A == A[1:end]
     @test A === A[:]
     @test A[1:2] === A[1:2]
     @test A[1:2] != A[1:3]
+    @test isa(A[1:2], ArrayView)
 
     # Test equality
     @test A == ones(20)

--- a/test/teststackarray.jl
+++ b/test/teststackarray.jl
@@ -1,9 +1,9 @@
-# Test MallocArray type
+# Test StackArray type
 
-    # Test MallocArray constructors
-    A = MallocArray{Float64}(undef, 20)
-    @test isa(A, MallocArray{Float64})
-    @test isa(A, MallocVector{Float64})
+    # Test StackArray constructors
+    A = StackArray{Float64}(undef, 20)
+    @test isa(A, StackArray{Float64})
+    @test isa(A, StackVector{Float64})
     @test length(A) == 20
     @test sizeof(A) == 20*sizeof(Float64)
     @test IndexStyle(A) == IndexLinear()
@@ -34,7 +34,7 @@
     @test ones(20) == A
     @test A == A
     B = copy(A)
-    @test isa(B, MallocArray)
+    @test isa(B, StackArray)
     @test A == B
     @test A !== B
     C = reshape(A, 5, 4)
@@ -54,42 +54,34 @@
     @test all(C .=== Float16(0))
 
     # Special indexing for 0d arrays
-    C = MallocArray{Float64}(undef, ())
+    C = StackArray{Float64}(undef, ())
     C[] = 1
     @test C[] === 1.0
     C[] = 2.0
     @test C[] === 2.0
-    @test free(C) == 0
 
     # Test other constructors
     C = similar(B)
-    @test isa(C, MallocArray{Float64,1})
+    @test isa(C, StackArray{Float64,1})
     @test isa(C[1], Float64)
     @test length(C) == 20
     @test size(C) == (20,)
-    @test free(C) == 0
 
     C = similar(B, 10, 10)
-    @test isa(C, MallocArray{Float64,2})
+    @test isa(C, StackArray{Float64,2})
     @test isa(C[1], Float64)
     @test length(C) == 100
     @test size(C) == (10,10)
-    @test free(C) == 0
 
     C = similar(B, Float32, 10)
-    @test isa(C, MallocArray{Float32,1})
+    @test isa(C, StackArray{Float32,1})
     @test isa(C[1], Float32)
     @test length(C) == 10
     @test size(C) == (10,)
-    @test free(C) == 0
-
-    # The end
-    @test free(A) == 0
-    @test free(B) == 0
 
     # Text constructor in higher dims
-    B = MallocMatrix{Float32}(undef, 10, 10)
-    @test isa(B, MallocArray{Float32,2})
+    B = StackMatrix{Float32}(undef, 10, 10)
+    @test isa(B, StackArray{Float32,2})
     @test size(B) == (10,10)
     @test length(B) == 100
     @test stride(B,1) == 1
@@ -98,10 +90,9 @@
     @test B[:,1] === B[:,1]
     @test B[3:7,1] === B[3:7,1]
     @test B[3:7,1] != B[4:7,1]
-    @test free(B) == 0
 
-    B = MallocArray{Int64,3}(undef,3,3,3)
-    @test isa(B, MallocArray{Int64,3})
+    B = StackArray{Int64,3}(undef,3,3,3)
+    @test isa(B, StackArray{Int64,3})
     @test size(B) == (3,3,3)
     @test length(B) == 27
     @test stride(B,1) == 1
@@ -116,10 +107,9 @@
     @test B[2,2,2] === 7
     B[:,:,2] .= 5
     @test B[2,2,2] === 5
-    @test free(B) == 0
 
-    B = MallocArray{Int64}(undef,2,2,2,2)
-    @test isa(B, MallocArray{Int64,4})
+    B = StackArray{Int64}(undef,2,2,2,2)
+    @test isa(B, StackArray{Int64,4})
     @test size(B) == (2,2,2,2)
     @test length(B) == 16
     @test stride(B,1) == 1
@@ -138,54 +128,45 @@
     @test B[2,2,2,2] === 5
     B[:,:,:,2] .= 3
     @test B[2,2,2,2] === 3
-    @test free(B) == 0
 
 ## -- test other constructors
 
-    A = MallocArray{Float64,2}(zeros, 11, 10)
+    A = sfill(0.0, 11,10)
     @test A == zeros(11,10)
     @test A[1] === 0.0
 
-    B = mzeros(11,10)
+    B = szeros(11,10)
     @test B == zeros(11,10)
     @test B[1] === 0.0
 
-    C = mzeros(Int32, 11,10)
+    C = szeros(Int32, 11,10)
     @test C == zeros(Int32, 11,10)
     @test C[1] === Int32(0)
 
-    D = mfill(Int32(0), 11,10)
+    D = sfill(Int32(0), 11,10)
     @test D == zeros(Int32, 11,10)
     @test D[1] === Int32(0)
 
     @test A == B == C == D
-    free(A)
-    free(B)
-    free(C)
-    free(D)
 
 ## ---
 
-    A = mones(11,10)
+    A = sones(11,10)
     @test A == ones(11,10)
     @test A[1] === 1.0
 
-    B = mones(Int32, 11,10)
+    B = sones(Int32, 11,10)
     @test B == ones(Int32, 11,10)
     @test B[1] === Int32(1.0)
 
     @test A == B
-    free(A)
-    free(B)
 
-    A = meye(10)
+    A = seye(10)
     @test A == I(10)
     @test A[5,5] === 1.0
 
-    B = meye(Int32, 10)
+    B = seye(Int32, 10)
     @test B == I(10)
     @test B[5,5] === Int32(1.0)
 
     @test A == B
-    free(A)
-    free(B)

--- a/test/teststaticcompiler.jl
+++ b/test/teststaticcompiler.jl
@@ -34,6 +34,7 @@ let
     @test isa(status, Base.Process) && status.exitcode == 0
     @test parsedlm(Int64, c"table.tsv", '\t') == (1:5)*(1:5)'
 end
+
 ## --- Random number generation
 
 let
@@ -156,9 +157,39 @@ let
     A = (1:10) * (1:5)'
     @test parsedlm(c"table.tsv",'\t') == A' * A
 end
+
+let
+    # Attempt to compile...
+    status = -1
+    try
+        isfile("loopvec_matrix_stack") && rm("loopvec_matrix_stack")
+        status = run(`julia --compile=min $testpath/scripts/loopvec_matrix_stack.jl`)
+    catch e
+        @warn "Could not compile $testpath/scripts/loopvec_matrix_stack.jl"
+        println(e)
+    end
+    @test isa(status, Base.Process)
+    @test isa(status, Base.Process) && status.exitcode == 0
+
+    # Run...
+    println("10x5 matrix product:")
+    status = -1
+    try
+        status = run(`./loopvec_matrix_stack`)
+    catch e
+        @warn "Could not run $(scratch)/loopvec_matrix_stack"
+        println(e)
+    end
+    @test isa(status, Base.Process)
+    @test isa(status, Base.Process) && status.exitcode == 0
+    A = (1:10) * (1:5)'
+    @test parsedlm(c"table.tsv",'\t') == A' * A
+end
+
+
 ## --- Test string handling
 
-    let
+let
     # Attempt to compile...
     status = -1
     try


### PR DESCRIPTION
* Adds a stack-allocated `StackArray` type that mirrors the syntax and conventions of `MallocArray`
* `StackArray`:`MallocArray`::`StaticString`:`MallocString`
* As with `StaticString` vs `MallocString`, the size of the stack-allocated option must be known at compile time to be `StaticCompiler`d
* Slice-indexing either a `StackArray` or a `MallocArray` now returns a lightweight `ArrayView` (similar to how slice-indexing either a `StaticString` or `MallocString` returns a `StringView` to avoid excessive copying