### PR TITLE
Support "withmallocarray"-type do-block syntax for most `MallocArray` constructors 

### DIFF
--- a/src/mallocarray.jl
+++ b/src/mallocarray.jl
@@ -38,6 +38,11 @@
 
     """
     ```julia
+    MallocArray(T, dims) do A
+        ...
+    end
+    ```
+    ```julia
     MallocArray{T}(undef, dims)
     MallocArray{T,N}(undef, dims)
     ```
@@ -82,6 +87,17 @@
     julia> free(A)
     0
     ```
+    To avoid having to manually `free` allocated memory, it is recommended to
+    use the following supported do-block syntax whenever possible, i.e.
+    ```julia
+    julia> MallocArray(Float64, 2, 2) do A
+               A .= 0
+               printf(A)
+           end
+    0.000000e+00    0.000000e+00
+    0.000000e+00    0.000000e+00
+    0
+    ```
     """
     @inline function MallocArray{T,N}(::UndefInitializer, length::Int, dims::Dims{N}) where {T,N}
         @assert Base.allocatedinline(T)
@@ -105,7 +121,7 @@
         free(M)
         y
     end
-    
+
     """
     ```julia
     MallocArray(data::AbstractArray{T,N})
@@ -152,6 +168,11 @@
     # Other custom constructors
     """
     ```julia
+    mzeros([T], dims) do A
+        ...
+    end
+    ```
+    ```julia
     mzeros([T=Float64,] dims::Tuple)
     mzeros([T=Float64,] dims...)
     ```
@@ -167,6 +188,16 @@
      0  0
      0  0
     ```
+    To avoid having to manually `free` allocated memory, it is recommended to
+    use the following supported do-block syntax whenever possible, i.e.
+    ```julia
+    julia> mzeros(2,2) do A
+               printf(A)
+           end
+    0.000000e+00    0.000000e+00
+    0.000000e+00    0.000000e+00
+    0
+    ```
     """
     @inline mzeros(dims::Vararg{Int}) = mzeros(dims)
     @inline mzeros(dims::Dims{N}) where {N} = MallocArray{Float64,N}(zeros, dims)
@@ -181,6 +212,11 @@
 
     """
     ```julia
+    mones([T=Float64,] dims) do A
+        ...
+    end
+    ```
+    ```julia
     mones([T=Float64,] dims::Tuple)
     mones([T=Float64,] dims...)
     ```
@@ -191,10 +227,23 @@
 
     ## Examples
     ```julia
-    julia> mones(Int32, 2,2)
+    julia> A = mones(Int32, 2,2)
     2×2 MallocMatrix{Int32}:
      1  1
      1  1
+
+    julia> free(A)
+    0
+    ```
+    To avoid having to manually `free` allocated memory, it is recommended to
+    use the following supported do-block syntax whenever possible, i.e.
+    ```julia
+    julia> mones(2,2) do A
+               printf(A)
+           end
+    1.000000e+00    1.000000e+00
+    1.000000e+00    1.000000e+00
+    0
     ```
     """
     @inline mones(dims...) = mones(Float64, dims...)
@@ -208,6 +257,11 @@
 
     """
     ```julia
+    meye([T=Float64,] dims) do A
+        ...
+    end
+    ```
+    ```julia
     meye([T=Float64,] dim::Int)
     ```
     Create a `MallocArray{T}` containing an identity matrix of type `T`,
@@ -215,10 +269,24 @@
 
     ## Examples
     ```julia
-    julia> meye(Int32, 2)
+    julia> A = meye(Int32, 2)
+
     2×2 MallocMatrix{Int32}:
      1  0
      0  1
+
+    julia> free(A)
+    0
+    ```
+    To avoid having to manually `free` allocated memory, it is recommended to
+    use the following supported do-block syntax whenever possible, i.e.
+    ```julia
+    julia> meye(2) do A
+               printf(A)
+           end
+    1.000000e+00    0.000000e+00
+    0.000000e+00    1.000000e+00
+    0
     ```
     """
     @inline meye(dim::Int) = meye(Float64, dim)
@@ -231,7 +299,7 @@
         return A
     end
     @inline function meye(f::Function, args...)
-        M = meye(T, args)
+        M = meye(args...)
         y = f(M)
         free(M)
         y
@@ -254,6 +322,16 @@
     2×2 MallocMatrix{Int64}:
      3  3
      3  3
+    ```
+    To avoid having to manually `free` allocated memory, it is recommended to
+    use the following supported do-block syntax whenever possible, i.e.
+    ```julia
+    julia> mfill(1.5, 2,2) do A
+               printf(A)
+           end
+    1.500000e+00    1.500000e+00
+    1.500000e+00    1.500000e+00
+    0
     ```
     """
     @inline mfill(x, dims::Vararg{Int}) = mfill(x, dims)

--- a/src/mallocarray.jl
+++ b/src/mallocarray.jl
@@ -99,7 +99,13 @@
     @inline MallocArray{T}(x::PointerOrInitializer, dims::Dims{N}) where {T,N} = MallocArray{T,N}(x, prod(dims), dims)
     @inline MallocArray{T,N}(x::PointerOrInitializer, dims::Vararg{Int}) where {T,N} = MallocArray{T,N}(x, prod(dims), dims)
     @inline MallocArray{T}(x::PointerOrInitializer, dims::Vararg{Int}) where {T} = MallocArray{T}(x, dims)
-
+    @inline function MallocArray(f::Function, T::Type, dims...)
+        M = MallocArray{T}(undef, dims...)
+        y = f(M)
+        free(M)
+        y
+    end
+    
     """
     ```julia
     MallocArray(data::AbstractArray{T,N})
@@ -126,6 +132,7 @@
     ```
     """
     @inline MallocArray(x::AbstractArray{T,N}) where {T,N} = copyto!(MallocArray{T,N}(undef, length(x), size(x)), x)
+
 
     # Destructor:
     @inline free(a::MallocArray) = free(a.pointer)
@@ -165,6 +172,12 @@
     @inline mzeros(dims::Dims{N}) where {N} = MallocArray{Float64,N}(zeros, dims)
     @inline mzeros(T::Type, dims::Vararg{Int}) = mzeros(T, dims)
     @inline mzeros(::Type{T}, dims::Dims{N}) where {T,N} = MallocArray{T,N}(zeros, dims)
+    @inline function mzeros(f::Function, args...)
+        M = mzeros(args...)
+        y = f(M)
+        free(M)
+        y
+    end
 
     """
     ```julia
@@ -186,6 +199,12 @@
     """
     @inline mones(dims...) = mones(Float64, dims...)
     @inline mones(::Type{T}, dims...) where {T} = mfill(one(T), dims...)
+    @inline function mones(f::Function, args...)
+        M = mones(T, args)
+        y = f(M)
+        free(M)
+        y
+    end
 
     """
     ```julia
@@ -211,6 +230,13 @@
         end
         return A
     end
+    @inline function meye(f::Function, args...)
+        M = meye(T, args)
+        y = f(M)
+        free(M)
+        y
+    end
+
 
     """
     ```julia
@@ -234,4 +260,10 @@
     @inline function mfill(x::T, dims::Dims{N}) where {T,N}
         A = MallocArray{T,N}(undef, prod(dims), dims)
         fill!(A, x)
+    end
+    @inline function mfill(f::Function, args...)
+        M = mfill(args...)
+        y = f(M)
+        free(M)
+        y
     end

--- a/src/mallocarray.jl
+++ b/src/mallocarray.jl
@@ -249,7 +249,7 @@
     @inline mones(dims...) = mones(Float64, dims...)
     @inline mones(::Type{T}, dims...) where {T} = mfill(one(T), dims...)
     @inline function mones(f::Function, args...)
-        M = mones(T, args)
+        M = mones(args...)
         y = f(M)
         free(M)
         y

--- a/test/scripts/withmallocarray.jl
+++ b/test/scripts/withmallocarray.jl
@@ -1,0 +1,21 @@
+using StaticCompiler
+using StaticTools
+
+function withmallocarray(argc::Int, argv::Ptr{Ptr{UInt8}})
+    argc == 3 || return printf(stderrp(), c"Incorrect number of command-line arguments\n")
+    rows = parse(Int64, argv, 2)            # First command-line argument
+    cols = parse(Int64, argv, 3)            # Second command-line argument
+
+    mzeros(rows, cols) do A
+        printf(A)
+    end
+    mones(Int, rows, cols) do A
+        printf(A)
+    end
+    mfill(3.141592, rows, cols) do A
+        printf(A)
+    end
+end
+
+# Attempt to compile
+path = compile_executable(withmallocarray, (Int64, Ptr{Ptr{UInt8}}), "./")

--- a/test/testmallocarray.jl
+++ b/test/testmallocarray.jl
@@ -203,3 +203,31 @@
     @test A == B
     free(A)
     free(B)
+
+## --- test "withmallocarray" pattern
+
+    s = MallocArray(Int64, 2, 2) do A
+            A .= 1
+            sum(A)
+        end
+    @test s === 4
+
+    s = mones(2, 2) do A
+            sum(A)
+        end
+    @test s === 4.0
+
+    s = mzeros(2, 2) do A
+            sum(A)
+        end
+    @test s === 0.0
+
+    s = meye(2) do A
+            sum(A)
+        end
+    @test s === 2.0
+
+    s = mfill(3.14, 2, 2) do A
+            sum(A)
+        end
+    @test s === 12.56


### PR DESCRIPTION
As suggested by @tkf [on Zulip](https://julialang.zulipchat.com/#narrow/stream/256674-compiler-plugins/topic/StaticCompiler.2Ejl'd.20standalone.20Hello.20World/near/272070295) and encouraged by @chriselrod 