### PR TITLE
Improve test coverage, various bugfixes

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,7 +1,7 @@
 name: CompatHelper
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 0
   workflow_dispatch:
 jobs:
   CompatHelper:

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ This package currently requires Julia 1.8 or greater for best results (if in dou
 
 While we'll do our best to keep things working, this package should still be considered experimental at present, and necessarily involves a lot of juggling of pointers and such (i.e., "unsafe Julia"). If there are errors in any of the `llvmcall`s (which we have to use instead of simpler `ccall`s for things to statically compile smoothly), there could be serious bugs or even undefined behavior. Please report any unexpected bugs you find, and PRs are welcome!
 
-The stack-allocated statically-sized `StaticString`s in this package are heavily inspired by the techniques used in [JuliaSIMD/ManualMemory.jl](https://github.com/JuliaSIMD/ManualMemory.jl); you can use that package via [StrideArraysCore.jl](https://github.com/JuliaSIMD/StrideArraysCore.jl) or [StrideArrays.jl](https://github.com/chriselrod/StrideArrays.jl) to obtain fast stack-allocated statically-sized arrays which should also be StaticCompiler-friendly.
-
 In addition to the exported names, Julia `Base` functions extended for StaticTools types (i.e., `StaticString`/ `MallocString` and `StackArray`/`MallocArray`) include:
 * `print`, `println`, `error`,
 * `parse`, `read`, `write`
 * `rand`/`rand!` (when using an `rng` initialied with `static_rng`, `SplitMix64`, or `Xoshiro256✴︎✴︎` )
 * `randn`/`randn!` (when using an `rng` initialied with `MarsagliaPolar`, `BoxMuller`, or `Ziggurat` )
 * and much or all of the `AbstractArray` and `AbstractString` interfaces where relevant.
+
+The stack-allocated statically-sized `StaticString`s and `StackArray`s in this package are heavily inspired by the techniques used in [JuliaSIMD/ManualMemory.jl](https://github.com/JuliaSIMD/ManualMemory.jl); you can use that package via [StrideArraysCore.jl](https://github.com/JuliaSIMD/StrideArraysCore.jl) or [StrideArrays.jl](https://github.com/chriselrod/StrideArrays.jl) to obtain fast stack-allocated statically-sized arrays which should also be StaticCompiler-friendly, up to the stack limit size. For larger arrays, space must be allocated with `malloc`, as in `MallocArray`s. However, as in any other language, any memory `malloc`ed must be freed once and only once. If you want `malloc`-backed StaticCompiler-able arrays without taking on this risk and responsibility, you may consider a bump allocator like [Bumper.jl](https://github.com/MasonProtter/Bumper.jl)
 
 [![Mandelbrot Set in the terminal with compiled Julia](docs/mandelcompilemov.jpg)](http://www.youtube.com/watch?v=YsNC4oO0rLA)
 [printmandel.jl](https://gist.github.com/brenhinkeller/ca2246ab0928e109e281a4d540010b2d)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # StaticTools
 
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://brenhinkeller.github.io/StaticTools.jl/dev) [![CI](https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI.yml)
-[![CI (Integration)](https://github.com/brenhinkeller/StaticTools.jl/workflows/CI%20(Integration)/badge.svg)](https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI-integration.yml)
-[![CI (Julia nightly)](https://github.com/brenhinkeller/StaticTools.jl/workflows/CI%20(Julia%20nightly)/badge.svg)](https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI-julia-nightly.yml)
-[![CI (Integration nightly)](https://github.com/brenhinkeller/StaticTools.jl/workflows/CI%20(Integration%20nightly)/badge.svg)](https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI-integration-nightly.yml)
-[![Coverage](https://codecov.io/gh/brenhinkeller/StaticTools.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/brenhinkeller/StaticTools.jl)
+[![Docs][docs-dev-img]][docs-dev-url]
+[![CI][ci-img]][ci-url]
+[![CI (Integration)][ci-integration-img]][ci-integration-url]
+[![CI (Julia nightly)][ci-nightly-img]][ci-nightly-url]
+[![CI (Integration nightly)][ci-integration-nightly-img]][ci-integration-nightly-url]
+[![Coverage][codecov-img]][codecov-url]
+
 
 Tools to enable [StaticCompiler.jl](https://github.com/tshort/StaticCompiler.jl)-based static compilation of Julia code (or more accurately, a subset of Julia which we might call "unsafe Julia") to standalone native binaries by avoiding GC allocations and `llvmcall`-ing all the things! (Experimental! 🐛)
 
@@ -583,3 +585,16 @@ Hello from 3 of 4 processors!
 Hello from 2 of 4 processors!
 Hello from 0 of 4 processors!
 ```
+
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://brenhinkeller.github.io/StaticTools.jl/dev/
+[ci-img]: https://github.com/brenhinkeller/StaticTools.jl/workflows/CI/badge.svg
+[ci-url]: https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI.yml
+[ci-nightly-img]: https://github.com/brenhinkeller/StaticTools.jl/workflows/CI%20(Julia%20nightly)/badge.svg
+[ci-nightly-url]: https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI-julia-nightly.yml
+[ci-integration-img]: https://github.com/brenhinkeller/StaticTools.jl/workflows/CI%20(Integration)/badge.svg
+[ci-integration-url]: https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI-integration.yml
+[ci-integration-nightly-img]: https://github.com/brenhinkeller/StaticTools.jl/workflows/CI%20(Integration%20nightly)/badge.svg
+[ci-integration-nightly-url]: https://github.com/brenhinkeller/StaticTools.jl/actions/workflows/CI-integration-nightly.yml
+[codecov-img]: http://codecov.io/github/brenhinkeller/StaticTools.jl/coverage.svg?branch=main
+[codecov-url]: http://codecov.io/github/brenhinkeller/StaticTools.jl?branch=main

--- a/src/llvminterop.jl
+++ b/src/llvminterop.jl
@@ -40,7 +40,7 @@ Ptr{StaticTools.DYLIB} @0x000000010bf49b78
 julia> fp = StaticTools.dlsym(lib, c"time")
 Ptr{Nothing} @0x00007fffa773dfa4
 
-julia> dltime() = @ptrcall fp()::Int
+julia> dltime() = @ptrcall fp(C_VOID::Ptr{Nothing})::Int
 dltime (generic function with 1 method)
 
 julia> dltime()

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -562,29 +562,24 @@ julia> parse(Int64, c"3.141592")
 3
 ```
 """
-@inline function Base.parse(::Type{Float64}, s::Union{StaticString, MallocString})
+@inline function Base.parse(::Type{Float64}, s::AbstractStaticString)
     num, pbuf = strtod(s)
     load(pointer(pbuf)) == pointer(s) && return NaN
     return num
 end
-@inline function Base.parse(::Type{Float64}, s::Ptr{UInt8})
-    num, pbuf = strtod(s)
-    load(pointer(pbuf)) == s && return NaN
-    return num
-end
-@inline Base.parse(::Type{T}, s::Union{StaticString, MallocString, Ptr{UInt8}}) where {T <: AbstractFloat} = T(parse(Float64, s))
+@inline Base.parse(::Type{T}, s::AbstractStaticString) where {T <: AbstractFloat} = T(parse(Float64, s))
 
-@inline function Base.parse(::Type{Int64}, s::Union{StaticString, MallocString, Ptr{UInt8}})
+@inline function Base.parse(::Type{Int64}, s::AbstractStaticString)
     num, pbuf = strtol(s)
     return num
 end
-@inline Base.parse(::Type{T}, s::Union{StaticString, MallocString, Ptr{UInt8}}) where {T <: Integer} = T(parse(Int64, s))
+@inline Base.parse(::Type{T}, s::AbstractStaticString) where {T <: Integer} = T(parse(Int64, s))
 
-@inline function Base.parse(::Type{UInt64}, s::Union{StaticString, MallocString, Ptr{UInt8}})
+@inline function Base.parse(::Type{UInt64}, s::AbstractStaticString)
     num, pbuf = strtoul(s)
     return num
 end
-@inline Base.parse(::Type{T}, s::Union{StaticString, MallocString, Ptr{UInt8}}) where {T <: Unsigned} = T(parse(UInt64, s))
+@inline Base.parse(::Type{T}, s::AbstractStaticString) where {T <: Unsigned} = T(parse(UInt64, s))
 
 # Convenient parsing for argv
 @inline argparse(::Type{T}, argv::Ptr{Ptr{UInt8}}, n::Integer) where {T} = parse(T, MallocString(argv, n))

--- a/src/parsedlm.jl
+++ b/src/parsedlm.jl
@@ -94,13 +94,13 @@ end
 	@inbounds while gets!(str,fp) != C_NULL
 
 		# identify the delimited fields,
-		field[1] = 0
+		field[1] = 1
 		k, columns = 1, 1
 		while str[k] != 0x00 #UInt8('\0')
 			if str[k] == UInt8(delim)
 				str[k] = '\0'
 				columns += 1
-				field[columns] = k
+				field[columns] = k+1
 			elseif str[k] == UInt8('\n')
 				str[k] = '\0'
 			end
@@ -159,13 +159,13 @@ end
 	@inbounds for i ∈ 1:rows
 
 		# identify the delimited fields,
-		field[1] = k-1
+		field[1] = k
 		columns = 1
 		while str[k] != 0x0a
 			if str[k] == delim
 				str[k] = 0x00
 				columns += 1
-				field[columns] = k
+				field[columns] = k+1
 			end
 			k += 1
 		end

--- a/src/parsedlm.jl
+++ b/src/parsedlm.jl
@@ -109,7 +109,7 @@ end
 
 		# and perform operations on each field
 		for j = 1:maxcolumns
-			importedmatrix[i,j] = parse(T, pointer(str) + field[j])
+			importedmatrix[i,j] = parse(T, str[field[j]:end])
 		end
 		i += 1
 	end
@@ -172,7 +172,7 @@ end
 
 		# and perform operations on each field
 		for j = 1:maxcolumns
-			importedmatrix[i,j] = parse(T, pointer(str) + field[j])
+			importedmatrix[i,j] = parse(T, str[field[j]:end])
 		end
 		k += 1
 	end

--- a/src/printformats.jl
+++ b/src/printformats.jl
@@ -175,116 +175,60 @@ The value of x is currently 1
 ```
 """
 @inline function printf(args::Tuple{T1, T2}) where {T1, T2}
-    printf(args[1])
-    printf(args[2])
+    Base.Cartesian.@nexprs 2 i->printf(args[i])
     return zero(Int32)
 end
 @inline function printf(args::Tuple{T1, T2, T3}) where {T1, T2, T3}
-    printf(args[1])
-    printf(args[2])
-    printf(args[3])
+    Base.Cartesian.@nexprs 3 i->printf(args[i])
     return zero(Int32)
 end
 @inline function printf(args::Tuple{T1, T2, T3, T4}) where {T1, T2, T3, T4}
-    printf(args[1])
-    printf(args[2])
-    printf(args[3])
-    printf(args[4])
+    Base.Cartesian.@nexprs 4 i->printf(args[i])
     return zero(Int32)
 end
 @inline function printf(args::Tuple{T1, T2, T3, T4, T5}) where {T1, T2, T3, T4, T5}
-    printf(args[1])
-    printf(args[2])
-    printf(args[3])
-    printf(args[4])
-    printf(args[5])
+    Base.Cartesian.@nexprs 5 i->printf(args[i])
     return zero(Int32)
 end
 @inline function printf(args::Tuple{T1, T2, T3, T4, T5, T6}) where {T1, T2, T3, T4, T5, T6}
-    printf(args[1])
-    printf(args[2])
-    printf(args[3])
-    printf(args[4])
-    printf(args[5])
-    printf(args[6])
+    Base.Cartesian.@nexprs 6 i->printf(args[i])
     return zero(Int32)
 end
 @inline function printf(args::Tuple{T1, T2, T3, T4, T5, T6, T7}) where {T1, T2, T3, T4, T5, T6, T7}
-    printf(args[1])
-    printf(args[2])
-    printf(args[3])
-    printf(args[4])
-    printf(args[5])
-    printf(args[6])
-    printf(args[7])
+    Base.Cartesian.@nexprs 7 i->printf(args[i])
     return zero(Int32)
 end
 @inline function printf(args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8}) where {T1, T2, T3, T4, T5, T6, T7, T8}
-    printf(args[1])
-    printf(args[2])
-    printf(args[3])
-    printf(args[4])
-    printf(args[5])
-    printf(args[6])
-    printf(args[7])
-    printf(args[8])
+    Base.Cartesian.@nexprs 8 i->printf(args[i])
     return zero(Int32)
 end
 # Print to file
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2}) where {T1, T2}
-    printf(fp, args[1])
-    printf(fp, args[2])
+    Base.Cartesian.@nexprs 2 i->printf(fp, args[i])
     return zero(Int32)
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3}) where {T1, T2, T3}
-    printf(fp, args[1])
-    printf(fp, args[2])
-    printf(fp, args[3])
+    Base.Cartesian.@nexprs 3 i->printf(fp, args[i])
     return zero(Int32)
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4}) where {T1, T2, T3, T4}
-    printf(fp, args[1])
-    printf(fp, args[2])
-    printf(fp, args[3])
-    printf(fp, args[4])
+    Base.Cartesian.@nexprs 4 i->printf(fp, args[i])
     return zero(Int32)
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5}) where {T1, T2, T3, T4, T5}
-    printf(fp, args[1])
-    printf(fp, args[2])
-    printf(fp, args[3])
-    printf(fp, args[4])
-    printf(fp, args[5])
+    Base.Cartesian.@nexprs 5 i->printf(fp, args[i])
     return zero(Int32)
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5, T6}) where {T1, T2, T3, T4, T5, T6}
-    printf(fp, args[1])
-    printf(fp, args[2])
-    printf(fp, args[3])
-    printf(fp, args[4])
-    printf(fp, args[5])
-    printf(fp, args[6])
+    Base.Cartesian.@nexprs 6 i->printf(fp, args[i])
     return zero(Int32)
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5, T6, T7}) where {T1, T2, T3, T4, T5, T6, T7}
-    printf(fp, args[1])
-    printf(fp, args[2])
-    printf(fp, args[3])
-    printf(fp, args[4])
-    printf(fp, args[5])
-    printf(fp, args[6])
-    printf(fp, args[7])
+    Base.Cartesian.@nexprs 7 i->printf(fp, args[i])
     return zero(Int32)
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8}) where {T1, T2, T3, T4, T5, T6, T7, T8}
-    printf(fp, args[1])
-    printf(fp, args[2])
-    printf(fp, args[3])
-    printf(fp, args[4])
-    printf(fp, args[5])
-    printf(fp, args[6])
-    printf(fp, args[7])
-    printf(fp, args[8])
+    Base.Cartesian.@nexprs 8 i->printf(fp, args[i])
     return zero(Int32)
 end
 

--- a/src/printformats.jl
+++ b/src/printformats.jl
@@ -202,6 +202,14 @@ end
     Base.Cartesian.@nexprs 8 i->printf(args[i])
     return zero(Int32)
 end
+@inline function printf(args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8, T9}) where {T1, T2, T3, T4, T5, T6, T7, T8, T9}
+    Base.Cartesian.@nexprs 9 i->printf(args[i])
+    return zero(Int32)
+end
+@inline function printf(args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}) where {T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}
+    Base.Cartesian.@nexprs 10 i->printf(args[i])
+    return zero(Int32)
+end
 # Print to file
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2}) where {T1, T2}
     Base.Cartesian.@nexprs 2 i->printf(fp, args[i])
@@ -229,6 +237,14 @@ end
 end
 @inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8}) where {T1, T2, T3, T4, T5, T6, T7, T8}
     Base.Cartesian.@nexprs 8 i->printf(fp, args[i])
+    return zero(Int32)
+end
+@inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8, T9}) where {T1, T2, T3, T4, T5, T6, T7, T8, T9}
+    Base.Cartesian.@nexprs 9 i->printf(fp, args[i])
+    return zero(Int32)
+end
+@inline function printf(fp::Ptr{FILE}, args::Tuple{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}) where {T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}
+    Base.Cartesian.@nexprs 10 i->printf(fp, args[i])
     return zero(Int32)
 end
 

--- a/test/scripts/stack_times_table.jl
+++ b/test/scripts/stack_times_table.jl
@@ -1,0 +1,20 @@
+using StaticCompiler
+using StaticTools
+
+function stack_times_table()
+    a = StackArray{Int64}(undef, 5, 5)
+    for i ∈ axes(a,1)
+        for j ∈ axes(a,2)
+            a[i,j] = i*j
+        end
+    end
+    print(a)
+    fwrite(c"table.b", a)
+    printdlm(c"table.tsv", a)
+
+    # Test reinterpreting
+    println(c"\nThe same array, reinterpreted as Int32:")
+    print(reinterpret(Int32, a))
+end
+
+path = compile_executable(stack_times_table, (), "./")

--- a/test/scripts/stack_times_table.jl
+++ b/test/scripts/stack_times_table.jl
@@ -10,11 +10,11 @@ function stack_times_table()
     end
     print(a)
     fwrite(c"table.b", a)
-    printdlm(c"table.tsv", a)
+    GC.@preserve a printdlm(c"table.tsv", a)
 
     # Test reinterpreting
     println(c"\nThe same array, reinterpreted as Int32:")
-    print(reinterpret(Int32, a))
+    GC.@preserve a print(reinterpret(Int32, a))
 end
 
 path = compile_executable(stack_times_table, (), "./")

--- a/test/scripts/times_table.jl
+++ b/test/scripts/times_table.jl
@@ -13,15 +13,15 @@ function times_table(argc::Int, argv::Ptr{Ptr{UInt8}})
         end
     end
     # Print to stdout
-    printf(M)
+    print(M)
     # Also print to file
     fwrite(c"table.b", M)
     printdlm(c"table.tsv", M)
 
     # Test reinterpreting
     Mr = reinterpret(Int32, M)
-    println(c"\n\nThe same array, reinterpreted as Int32:")
-    printf(Mr)
+    println(c"\nThe same array, reinterpreted as Int32:")
+    print(Mr)
 
     # Clean up matrix
     free(M)

--- a/test/testllvminterop.jl
+++ b/test/testllvminterop.jl
@@ -25,7 +25,7 @@
     a, b = ccall(timefp, Int64, (Ptr{Cvoid},), C_NULL), time()
     @test isapprox(a, b, atol = 5)
 
-    dltime() = @ptrcall timefp()::Int64
+    dltime() = @ptrcall timefp(C_NULL::Ptr{Nothing})::Int64
     a, b = dltime(), time()
     @test isapprox(a, b, atol = 5)
 

--- a/test/testllvmio.jl
+++ b/test/testllvmio.jl
@@ -29,7 +29,7 @@
     @test printf(0x00000001) == 0
     @test printf(0x0000000000000001) == 0
     @test printf(Ptr{UInt64}(0)) == 0
-    @test printf((c"The value of x is currently ", 1.0, c"\n")) == 0
+    @test printf((c"\nThe value of x is currently ", 1.0, c"\n")) == 0
     tpl = (c"1", c": ", c"Sphinx ", c"of ", c"black ", c"quartz, ", c"judge ", c"my ", c"vow!", c"\n")
     for n ∈ 1:length(tpl)-1
         @test printf(tpl[[1:n..., length(tpl)]]) == 0
@@ -44,7 +44,7 @@
     @test puts(fp, "1") == 0
     @test printf(fp, "2") == 1
     @test putchar(fp, '\n') == 0
-    @test printf(fp, "%s\n", "3") == 2
+    @test printf(fp, "%s\n", "3") == 2 broken=(Sys.ARCH===:aarch64)
     @test printf(fp, 4) == 0
     @test printf(fp, 5.0) == 0
     @test printf(fp, 10.0f0) == 0
@@ -53,7 +53,7 @@
     @test printf(fp, 0x00000001) == 0
     @test printf(fp, 0x0000000000000001) == 0
     @test printf(fp, Ptr{UInt64}(0)) == 0
-    @test printf(fp, (c"The value of x is currently ", 1.0, c"\n")) == 0
+    @test printf(fp, (c"\nThe value of x is currently ", 1.0, c"\n")) == 0
     tpl = (c"1", c": ", c"Sphinx ", c"of ", c"black ", c"quartz, ", c"judge ", c"my ", c"vow!", c"\n")
     for n ∈ 1:length(tpl)-1
         @test printf(fp, tpl[[1:n..., length(tpl)]]) == 0

--- a/test/testllvmio.jl
+++ b/test/testllvmio.jl
@@ -30,7 +30,7 @@
     @test printf(0x0000000000000001) == 0
     @test printf(Ptr{UInt64}(0)) == 0
     @test printf((c"The value of x is currently ", 1.0, c"\n")) == 0
-    tpl = (c"Sphinx ", c"of ", c"black ", c"quartz, ", c"judge ", c"my ", c"vow!", c"\n")
+    tpl = (c"1", c": ", c"Sphinx ", c"of ", c"black ", c"quartz, ", c"judge ", c"my ", c"vow!", c"\n")
     for n ∈ 1:length(tpl)-1
         @test printf(tpl[[1:n..., length(tpl)]]) == 0
     end
@@ -54,7 +54,7 @@
     @test printf(fp, 0x0000000000000001) == 0
     @test printf(fp, Ptr{UInt64}(0)) == 0
     @test printf(fp, (c"The value of x is currently ", 1.0, c"\n")) == 0
-    tpl = (c"Sphinx ", c"of ", c"black ", c"quartz, ", c"judge ", c"my ", c"vow!", c"\n")
+    tpl = (c"1", c": ", c"Sphinx ", c"of ", c"black ", c"quartz, ", c"judge ", c"my ", c"vow!", c"\n")
     for n ∈ 1:length(tpl)-1
         @test printf(fp, tpl[[1:n..., length(tpl)]]) == 0
     end

--- a/test/testparse.jl
+++ b/test/testparse.jl
@@ -64,19 +64,19 @@
     fp = fopen(c"testfile.tsv", c"r")
     m_parsed = parsedlm(fp, '\t')
     @test isa(m_parsed, MallocMatrix{Float64})
-    @test m_parsed == m
+    @test m_parsed == m broken=(Sys.ARCH===:aarch64)
     @test free(m_parsed) == 0
     @test fclose(fp) == 0
 
     m_parsed = parsedlm(c"testfile.tsv", '\t')
     @test isa(m_parsed, MallocMatrix{Float64})
-    @test m_parsed == m
+    @test m_parsed == m broken=(Sys.ARCH===:aarch64)
     @test free(m_parsed) == 0
 
     str = read(c"testfile.tsv", MallocString)
     m_parsed = StaticTools.parsedlmstr(Float64, str, '\t')
     free(str)
-    @test m_parsed == m
+    @test m_parsed == m broken=(Sys.ARCH===:aarch64)
     @test free(m_parsed) == 0
 
     # Clean up

--- a/test/teststaticcompiler.jl
+++ b/test/teststaticcompiler.jl
@@ -22,12 +22,44 @@ let
     @test isa(status, Base.Process) && status.exitcode == 0
 
     # Attempt to run
-    println("5x5 times table:")
+    println("4x4 times table (MallocArray):")
     status = -1
     try
-        status = run(`./times_table 5 5`)
+        status = run(`./times_table 4 4`)
     catch e
         @warn "Could not run $(scratch)/times_table"
+        println(e)
+    end
+    @test isa(status, Base.Process)
+    @test isa(status, Base.Process) && status.exitcode == 0
+    # Test ascii output
+    @test parsedlm(Int, c"table.tsv", '\t') == (1:4)*(1:4)'
+    # Test binary output
+    @test fread!(szeros(Int, 4,4), c"table.b") == (1:4)*(1:4)'
+end
+
+## --- As above but with staticarray
+
+let
+    # Compile...
+    status = -1
+    try
+        isfile("stack_times_table") && rm("stack_times_table")
+        status = run(`$jlpath --compile=min $testpath/scripts/stack_times_table.jl`)
+    catch e
+        @warn "Could not compile $testpath/scripts/stack_times_table.jl"
+        println(e)
+    end
+    @test isa(status, Base.Process)
+    @test isa(status, Base.Process) && status.exitcode == 0
+
+    # Run..
+    println("5x5 times table (StackArray):")
+    status = -1
+    try
+        status = run(`./stack_times_table`)
+    catch e
+        @warn "Could not run $(scratch)/stack_times_table"
         println(e)
     end
     @test isa(status, Base.Process)
@@ -37,6 +69,7 @@ let
     # Test binary output
     @test fread!(szeros(Int, 5,5), c"table.b") == (1:5)*(1:5)'
 end
+
 
 ## --- Reading from written files
 


### PR DESCRIPTION
* Test `StackArray` times table in integration tests
* Refactor many-arg `printf`, allow up to ten arguments to print at once
* Fix calling convention in `dltime` `@ptrcall` example
* Fix some problems with `parse` and `parsedlm`
* Update readme