### PR TITLE
feat: Add support for `Base.iterate` and `Base.startswith`.

### DIFF
--- a/src/staticstring.jl
+++ b/src/staticstring.jl
@@ -144,3 +144,4 @@
     # Implement some of the AbstractString interface -- where overriding AbstractStaticString defaults
     @inline Base.ncodeunits(s::StaticString{N}) where N = N
     @inline Base.codeunits(s::StaticString) = s.data
+

--- a/test/teststaticstring.jl
+++ b/test/teststaticstring.jl
@@ -62,3 +62,7 @@
     @test contains(str, c"foo")
     @test contains(str, c"bar")
     @test contains(str, c"baz")
+    @test startswith(str, c"foo")
+    @test !startswith(c"foo", str)
+    @test !startswith(str, c"g")
+


### PR DESCRIPTION
Fix #35 