### PR TITLE
Feat add view support

### DIFF
--- a/src/abstractstaticstring.jl
+++ b/src/abstractstaticstring.jl
@@ -14,6 +14,8 @@
         length::Int
     end
     @inline Base.length(s::StringView) = s.length
+    @inline StringView(s::AbstractStaticString, r::AbstractUnitRange{<:Integer}) = StringView(pointer(s)+first(r)-1, length(r))
+
 
     # Custom replshow for interactive use (n.b. _NOT_ static-compilerable)
     function Base.show(io::IO, s::StringView)
@@ -85,6 +87,7 @@
             s[i] = x[i+ix₀]
         end
     end
+    Base.view(s::AbstractStaticString, r::AbstractUnitRange{<:Integer}) = StringView(s, r)
 
     # Some of the AbstractString interface
     @inline Base.ncodeunits(s::AbstractPointerString) = s.length

--- a/test/teststaticstring.jl
+++ b/test/teststaticstring.jl
@@ -65,4 +65,21 @@
     @test startswith(str, c"foo")
     @test !startswith(c"foo", str)
     @test !startswith(str, c"g")
-
+    @test isvalid(c"foo", 1)
+    @test !isvalid(c"foo", 9999)
+    @test endswith(c"foobar", c"bar")
+    @test !endswith(c"foobar", c"baz")
+    @test isvalid(c"α", 1)
+    @test !isvalid(c"α", 2)
+    @test thisind(c"α", 2) == 1
+    @test thisind(c"α", 1) == 1
+    @test nextind(c"α", 0) == 1
+    @test nextind(c"α", 1) == 3
+    @test nextind(c"α", 3) == 3
+    @test nextind(c"α", 0, 2) == 3
+    @test nextind(c"α", 1, 2) == 4
+    @test prevind(c"α", 3) == 1
+    @test prevind(c"α", 1) == 0
+    @test prevind(c"α", 0) == 0
+    @test prevind(c"α", 2, 2) == 0
+    @test prevind(c"α", 2, 3) == -1

--- a/test/teststaticstring.jl
+++ b/test/teststaticstring.jl
@@ -83,3 +83,5 @@
     @test prevind(c"α", 0) == 0
     @test prevind(c"α", 2, 2) == 0
     @test prevind(c"α", 2, 3) == -1
+    @test view(c"foobar", 1:3) == "foo"
+    @test view(c"foobar", 1:3) isa StringView


### PR DESCRIPTION
Add support for `Base.view`, so that you can do:

```julia
a = c"foobar"
v = view(a, 1:3)
v isa StringView
v == "foo"
```

Note: #37 must be merged first, I started my branch from the wrong branch, sorry!