### PR TITLE
Iteration Base API

### DIFF
--- a/src/StaticTools.jl
+++ b/src/StaticTools.jl
@@ -59,7 +59,7 @@ module StaticTools
     export usleep                                                               # Other libc utility functions
     export newline, putchar, getchar, getc, puts, gets!, readline!              # Char & String IO
     export fwrite, fread!                                                       # String and Binary IO
-    export unsafe_mallocstring, strlen, iterate_stable                          # String management
+    export unsafe_mallocstring, strlen                                          # String management
     export printf, printdlm, parsedlm, argparse                                 # File parsing and formatting
     export static_rng, splitmix64, xoshiro256✴︎✴︎, rand!, randn!                  # RNG functions
 end

--- a/src/abstractstaticstring.jl
+++ b/src/abstractstaticstring.jl
@@ -129,7 +129,7 @@
 
     # Adapted from Julia's stdlib
     """
-        iterate_stable(s::AbstractStaticString, i=firstindex(s))
+        iterate(s::AbstractStaticString, i=firstindex(s))
 
     Adapted form Julia's stdlib, but made type-stable.
 
@@ -144,15 +144,15 @@
     julia> s = c"foo"
     c"foo"
 
-    julia> iterate_stable(s, 1)
+    julia> iterate(s, 1)
     ('f', 2)
 
-    julia> iterate_stable(s, 99999)
+    julia> iterate(s, 99999)
     ('\\0', 99999)
     ```
     """
-    @inline function iterate_stable(s::AbstractStaticString, i::Int=firstindex(s))
-        ((i % UInt) - 1 < ncodeunits(s) && s[i] ≠ 0x00) || return ('\0', i)
+    @inline function Base.iterate(s::AbstractStaticString, i::Int=firstindex(s))
+        ((i % UInt) - 1 < ncodeunits(s) && s[i] ≠ 0x00) || return nothing
         b = @inbounds codeunit(s, i)
         u = UInt32(b) << 24
         between(b, 0x80, 0xf7) || return reinterpret(Char, u), i+1
@@ -277,22 +277,4 @@
             @inbounds n -= isvalid(s, i += 1)
         end
         return i + n
-    end
-    @inline function Base.endswith(a::AbstractStaticString, b::AbstractStaticString)
-        i, j = iterate_stable(a, prevind(a, lastindex(a))), iterate_stable(b, prevind(b, lastindex(b)))
-        while true
-            j[2] < firstindex(b) && return true # ran out of suffix: success!
-            i[2] < firstindex(a) && return false # ran out of source: failure
-            i[1] == j[1] || return false # mismatch: failure
-            i, j = iterate_stable(a, prevind(a, i[2], 2)), iterate_stable(b, prevind(b, j[2], 2))
-        end
-    end
-    @inline function Base.startswith(a::AbstractStaticString, b::AbstractStaticString)
-       i, j = iterate_stable(a), iterate_stable(b)
-       while true
-           j[1] === '\0' && return true # ran out of prefix: success!
-           i[1] === '\0' && return false # ran out of source: failure
-           i[1] == j[1] || return false # mismatch: failure
-           i, j = iterate_stable(a, i[2]), iterate_stable(b, j[2])
-        end
     end

--- a/src/abstractstaticstring.jl
+++ b/src/abstractstaticstring.jl
@@ -131,12 +131,7 @@
     """
         iterate(s::AbstractStaticString, i=firstindex(s))
 
-    Adapted form Julia's stdlib, but made type-stable.
-
-    !!! warning "Return type"
-
-        The interface is a bit different from `Base`. When iterating outside of
-        the string, it will return the Null character and the current index.
+    Adapted form Julia's stdlib.
 
     # Examples
 
@@ -148,7 +143,7 @@
     ('f', 2)
 
     julia> iterate(s, 99999)
-    ('\\0', 99999)
+    
     ```
     """
     @inline function Base.iterate(s::AbstractStaticString, i::Int=firstindex(s))


### PR DESCRIPTION
This changes the iteration to support the Base API to return Nothing as appropriate. The following example statically compiles:

```jl
using StaticCompiler
using StaticTools
using Libdl

function testfun1()
    if startswith(c"foobar", c"foo")
        return 1
    else
        return 0
    end
end

name = repr(testfun1)
filepath = compile_shlib(testfun1, (), "./", name)

# Open dylib
ptr = Libdl.dlopen(filepath, Libdl.RTLD_LOCAL)
fptr = Libdl.dlsym(ptr, "julia_$name")
ccall(fptr, Int, ())

```

