### PR TITLE
Add `MallocSlabBuffer` and Bumper.jl compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticTools"
 uuid = "86c06d3c-3f03-46de-9781-57580aa96d0a"
 authors = ["C. Brenhin Keller and contributors"]
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,5 +13,5 @@ Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 [compat]
 ManualMemory = "0.1.8"
 LoopVectorization = "0.12"
-Bumper = "0.5.3"
+Bumper = "0.5.3, 0.6"
 julia = "1.7"

--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,10 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 ManualMemory = "d125e4d3-2237-4719-b19c-fa641b8a4667"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 
 [compat]
 ManualMemory = "0.1.8"
 LoopVectorization = "0.12"
+Bumper = "0.5.3"
 julia = "1.7"

--- a/src/StaticTools.jl
+++ b/src/StaticTools.jl
@@ -3,6 +3,7 @@ module StaticTools
     # External dependencies
     using ManualMemory: MemoryBuffer, load, store!
     using LoopVectorization
+    using Bumper
     # Import so we can extend
     import Random: rand!, randn!
     import LinearAlgebra: mul!
@@ -22,6 +23,7 @@ module StaticTools
     include("staticlinearalgebra.jl")  # Shared array infrastructure
     include("stackarray.jl")           # StackArray, StackMatrix, StackVector
     include("mallocarray.jl")          # MallocArray, MallocMatrix, MallocVector
+    include("bumper.jl")               # Interop with Bumper.jl for efficient bump allocation
 
     # Union of things that don't need GC.@protect
     const AbstractMallocdMemory = Union{MallocString, MallocArray}
@@ -47,12 +49,14 @@ module StaticTools
     export MallocArray, MallocMatrix, MallocVector                              # Heap-allocated array types
     export StackArray, StackMatrix, StackVector                                 # Stack-allocated array types
     export ArrayView
-    export SplitMix64, Xoshiro256✴︎✴︎, BoxMuller, MarsagliaPolar, Ziggurat        # RNG types
+    export SplitMix64, Xoshiro256✴︎✴︎, BoxMuller, MarsagliaPolar, Ziggurat      # RNG types
     export StaticContext, DefaultStaticContext                                  # Context for `static_type`
+    export MallocSlabBuffer
 
     # Macros
     export @c_str, @m_str, @mm_str
     export @ptrcall, @symbolcall, @externptr, @externload
+    export @no_escape, @alloc, @alloc_ptr
 
     # Functions
     export ⅋, malloc, calloc, free, memset!, memcpy!, memcmp                    # Memory management
@@ -65,6 +69,7 @@ module StaticTools
     export fwrite, fread!                                                       # String and Binary IO
     export unsafe_mallocstring, strlen                                          # String management
     export printf, printdlm, parsedlm, argparse                                 # File parsing and formatting
-    export static_rng, splitmix64, xoshiro256✴︎✴︎, rand!, randn!                  # RNG functions
+    export static_rng, splitmix64, xoshiro256✴︎✴︎, rand!, randn!                # RNG functions
     export static_type, static_type_contents                                    # Utilities
+
 end

--- a/src/bumper.jl
+++ b/src/bumper.jl
@@ -1,0 +1,226 @@
+
+
+
+struct MallocSlabBufferData
+    current         ::Ptr{Nothing}
+    slab_end        ::Ptr{Nothing}
+    slab_size       ::Int
+    slabs           ::Ptr{Ptr{Nothing}}
+    slabs_length    ::Int
+    slabs_max_length::Int
+    custom_slabs           ::Ptr{Ptr{Nothing}}
+    custom_slabs_length    ::Int
+    custom_slabs_max_length::Int
+
+    function MallocSlabBufferData(;slab_size::Int = 1_048_576, slabs_max_length::Int=8, custom_slabs_max_length::Int=64) 
+        current::Ptr{Nothing}  = malloc(slab_size)
+        slab_end = current + slab_size
+        
+        slabs::Ptr{Ptr{Nothing}} = malloc(slabs_max_length*sizeof(Ptr{Nothing}))
+        unsafe_store!(slabs, current, 1)
+        custom_slabs::Ptr{Ptr{Nothing}} = malloc(custom_slabs_max_length*sizeof(Ptr{Nothing}))
+
+        new(current, slab_end, slab_size, slabs, 1, slabs_max_length, custom_slabs, 0, custom_slabs_max_length)
+    end
+end
+
+
+"""
+    MallocSlabBuffer(;slab_size::Int = 1_048_576, slabs_max_length::Int=8, custom_slabs_max_length::Int=64)
+
+A StaticCompiler.jl friendly version of `SlabBuffer` from [Bumper.jl](https://github.com/MasonProtter/Bumper.jl).
+This should be the preferred way to manage dynamically sized memory without support from the julia runtime.
+
+`MallocSlabBuffer` is what's known as a slab-based bump allocator. It stores a list of fixed size memory 'slabs'
+(of size `slab_size` bytes), and memory can be requested from those slabs very fast. For allocations larger
+than half the `slab_size`, we do a size-specific `malloc` call and store the pointer in a separate list of custom
+sized slabs. At the end of a `@no_escape` block (see [Bumper.jl](https://github.com/MasonProtter/Bumper.jl)), any
+unneeded slabs (custom or fixed-size) are `free`d.
+
+The keyword arguments `slabs_max_length` and `custom_slabs_max_length` determine how many slabs and custom slabs
+the allocator is set to be able to initially store. If you dynamically allocate more slabs or custom slabs than
+these parameters, the `MallocSlabBuffer` will automatically resize itself to be able to store more slabs. These
+parameters are just heuristics for the initial creation of the allocator.
+
+`MallocSlabBuffer`s should be freed once you are done with them.
+
+----------------------
+
+Example usage:
+
+    function slab_benchmark(argc::Int, argv::Ptr{Ptr{UInt8}})
+        argc == 2 || return printf(c"Incorrect number of command-line arguments\n")
+        Nevals = argparse(Int64, argv, 2) # First command-line argument
+        # Create a slab buffer
+        buf = MallocSlabBuffer()
+        @no_escape buf begin
+            # Create some vector x of length 10 containing all 1s.
+            x = @alloc(Int, 10)
+            x .= 1
+            for i ∈ 1:Nevals
+                # Start a new no_escape block so that allocations created during this
+                # block get freed up at the end
+                @no_escape buf begin
+                    # Do some allocating operations in the loop
+                    y = @alloc(Int, 10)
+                    y .= x .+ 1
+                    # It's vital that we never allow an array created by alloc to ever
+                    # escape a @no_escape block!
+                    sum(y) 
+                end
+            end
+            nothing
+        end
+        # release the buffer once you're done with it.
+        free(buf)
+    end
+
+    julia> compile_executable(slab_benchmark, (Int64, Ptr{Ptr{UInt8}}), "./");
+
+    shell> time ./slab_benchmark 1000000000
+    real    0m2.417s
+    user    0m2.408s
+    sys     0m0.000s
+
+-------------------------
+
+Implementation notes:
+
++ MallocSlabBuffer stores a pointer to a `MallocSlabBufferData` so it can mutate the object without being a `mutable` type.
++ It stores a set of memory "slabs" of size `slab_size` (default 1 megabyte). 
++ the `current` field is the currently active pointer that a newly `@alloc`'d object will aquire, if the object fits between `current` and `slab_end`.
++ If the object does not fit between `current` and `slab_end`, but is smaller than `slab_size`, we'll `malloc` a new slab,  and add it to `slabs` (reallocating the `slabs` pointer if there's not enough room, as determined by `max_slabs_length`) and then set that thing as the `current` pointer, and provide that to the object.
++ If the object is bigger than `slab_size`, then we `malloc` a pointer of the requested size, and add it to the `custom_slabs` pointer  (also reallocating that pointer if necessary), leaving `current` and `slab_end` unchanged.
++ When a `@no_escape` block ends, we reset `current`, and `slab_end` to their old values, and if `slabs` or `custom_slabs` have grown, we `free` all the pointers that weren't present before, and reset their respective `length`s (but not `max_size`s).
+
+
+
+"""
+struct MallocSlabBuffer
+    ptr::Ptr{MallocSlabBufferData}
+    function MallocSlabBuffer(;kwargs...)
+        ptr::Ptr{MallocSlabBufferData} = malloc(sizeof(MallocSlabBufferData))
+        unsafe_store!(ptr, MallocSlabBufferData(;kwargs...), 1)
+        new(ptr)
+    end
+end
+
+let
+    ex = quote
+        p = getfield(buf, :ptr)
+    end
+    for i ∈ 1:fieldcount(MallocSlabBufferData)
+        cond = quote
+            if s === $(QuoteNode(fieldname(MallocSlabBufferData, i)));
+                T = $(fieldtype(MallocSlabBufferData, i))
+                offset = $(fieldoffset(MallocSlabBufferData, i))
+            end
+        end
+        push!(ex.args, cond)
+    end
+    
+    @eval function Base.getproperty(buf::MallocSlabBuffer, s::Symbol)
+        $ex
+        unsafe_load(convert(Ptr{T}, p + offset))
+    end
+    
+    @eval function Base.setproperty!(buf::MallocSlabBuffer, s::Symbol, x)
+        $ex
+        unsafe_store!(convert(Ptr{T}, p + offset), convert(T, x))
+    end
+end
+
+Base.propertynames(buf::MallocSlabBuffer) = fieldnames(MallocSlabBufferData)
+
+function free(buf::MallocSlabBuffer)
+    for i ∈ 1:buf.slabs_length
+        free(unsafe_load(buf.slabs, i))
+    end
+    for i ∈ 1:buf.custom_slabs_length
+        free(unsafe_load(buf.custom_slabs, i))
+    end
+    free(buf.slabs)
+    free(buf.custom_slabs)
+    free(getfield(buf, :ptr))
+end
+
+function Bumper.alloc_ptr!(buf::MallocSlabBuffer, sz::Int)::Ptr{Nothing} 
+    p = buf.current
+    next = buf.current + sz
+    if next > buf.slab_end
+        p = add_new_slab!(buf, sz)
+    else
+        buf.current = next
+    end
+    p
+end
+
+@noinline function add_new_slab!(buf::MallocSlabBuffer, sz::Int)::Ptr{Nothing}
+    if sz >= (buf.slab_size ÷ 2)
+        custom = malloc(sz)
+        if buf.custom_slabs_length > buf.custom_slabs_max_length
+            buf.custom_slabs_max_length += 64
+            new_custom_slabs::Ptr{Ptr{Nothing}} = malloc(buf.custom_slabs_max_length)
+            for i ∈ 1:buf.custom_slabs_length
+                unsafe_store!(new_custom_slabs, unsafe_load(buf.custom_slabs, i), i)
+            end
+            free(buf.custom_slabs)
+            buf.custom_slabs = new_custom_slabs
+        end
+        buf.custom_slabs_length += 1
+        unsafe_store!(buf.custom_slabs, custom, buf.custom_slabs_length)
+        custom
+    else
+        new_slab = malloc(buf.slab_size)
+        if buf.slabs_length >= buf.slabs_max_length
+            buf.slabs_max_length += 64
+            new_slabs::Ptr{Ptr{Nothing}} = malloc(buf.slabs_max_length + 64)
+            for i ∈ 1:buf.slabs_length
+                unsafe_store!(new_slabs, unsafe_load(buf.slabs, i), i)
+            end
+            free(buf.slabs)
+            buf.slabs = new_slabs
+        end
+        buf.current = new_slab + sz
+        buf.slab_end = new_slab + buf.slab_size
+        buf.slabs_length += 1
+        unsafe_store!(buf.slabs, new_slab, buf.slabs_length)
+        new_slab
+    end
+end
+
+struct MallocSlabCheckpoint
+    buf::MallocSlabBuffer
+    current::Ptr{Nothing}
+    slab_end::Ptr{Nothing}
+    slabs_length::Int
+    custom_slabs_length::Int
+end
+
+function Bumper.checkpoint_save(buf::MallocSlabBuffer)
+    MallocSlabCheckpoint(buf, buf.current, buf.slab_end, buf.slabs_length, buf.custom_slabs_length)
+end
+
+@noinline function restore_slabs!(slabs, slabs_length, cp_slabs_length)
+    for i ∈ (cp_slabs_length+1):slabs_length
+        free(unsafe_load(slabs, i))
+    end
+end
+
+@inline function Bumper.checkpoint_restore!(cp::MallocSlabCheckpoint)
+    buf = cp.buf
+    slabs = buf.slabs
+    custom = buf.custom_slabs
+
+    if buf.slabs_length > cp.slabs_length
+        restore_slabs!(buf.slabs, buf.slabs_length, cp.slabs_length)
+        buf.slabs_length = cp.slabs_length
+    end
+    if buf.custom_slabs_length > cp.custom_slabs_length
+        restore_slabs!(buf.custom_slabs, buf.custom_slabs_length, cp.custom_slabs_length)
+        buf.custom_slabs_length = cp.custom_slabs_length
+    end
+    buf.current  = cp.current
+    buf.slab_end = cp.slab_end 
+    nothing
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 ManualMemory = "d125e4d3-2237-4719-b19c-fa641b8a4667"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ const GROUP = get(ENV, "GROUP", "All")
     @testset "libc" begin include("testllvmlibc.jl") end
     @testset "interop" begin include("testllvminterop.jl") end
     @testset "Parsing" begin include("testparse.jl") end
+    @testset "MallocSlabBuffer" begin include("testslab.jl") end
     @testset "StaticString" begin include("teststaticstring.jl") end
     @testset "MallocString" begin include("testmallocstring.jl") end
     @testset "MallocArray" begin include("testmallocarray.jl") end

--- a/test/testslab.jl
+++ b/test/testslab.jl
@@ -1,0 +1,38 @@
+sb = MallocSlabBuffer(;slab_size=16_384, slabs_max_length=1, custom_slabs_max_length=0)
+
+@no_escape sb begin
+    p = sb.current
+    e = sb.slab_end
+    # Allocate something that takes up almost all the room on the slab
+    x1 = @alloc(Int8, 16_384÷2 - 1)
+    x2 = @alloc(Int8, 16_384÷2 - 1)
+    @test pointer(x1) == p
+    @test pointer(x2) == pointer(x1) + 16_384÷2 - 1
+    @test sb.slabs_max_length == 1
+    @test sb.slabs_length == 1
+    for i ∈ 1:5
+        @no_escape sb begin
+            @test sb.current == p + 16_384 - 2
+            @test p <= sb.current <= e
+            # Allocate a new vector that won't fit on the old slab
+            y = @alloc(Int, 10)
+            # A new slab was allocated automatically
+            @test !(p <= sb.current <= e)
+            @test sb.slabs_length == 2
+
+            @test sb.slabs_max_length == 65
+        end
+    end
+    @test sb.custom_slabs_max_length == 0
+    # Allocate something too big to fit on any slab
+    z = @alloc(Int, 100_000)
+    @test sb.custom_slabs_max_length == 0
+    
+    # This doesn't effect sb.current
+    @test sb.current == p + 16_384 - 2
+    @test sb.current == p + 16_384 - 2
+    @test sb.slab_end == e
+    @test !(p <= pointer(z) <= e)
+    # The pointer for z is tracked in the custom_slabs field instead
+    @test pointer(z) == unsafe_load(sb.custom_slabs, sb.custom_slabs_length)
+end

--- a/test/teststaticcompiler.jl
+++ b/test/teststaticcompiler.jl
@@ -193,7 +193,7 @@ let
 end
 
 ## --- Test LoopVectorization integration
-@static if LoopVectorization.VectorizationBase.has_feature(Val{:x86_64_avx2})
+@static if Bool(LoopVectorization.VectorizationBase.has_feature(Val{:x86_64_avx2}))
     let
         # Compile...
         status = -1


### PR DESCRIPTION
This might cause some testing problems on v1.9+ without https://github.com/MasonProtter/Bumper.jl/pull/31 being merged, because of a circular dependency with StaticCompiler.jl, but other than that I think this implementation should be more or less working.

It's basically a re-implementation of https://github.com/MasonProtter/Bumper.jl/blob/515a4dd405de71da6621dd7b72841c6c794f2c2c/src/SlabBuffer.jl  except it uses no mutable types and no `Vector`s, implementing everything via pointers directly, including the resizing of the slab queues. 

MallocSlabBuffer's implementation is kinda scary looking, but it's actually not **that** complicated. Here's a rundown of how it works:

+ It stores a set of memory "slabs" of size `slab_size` (default 1 megabyte). 
+ the `current` field is the currently active pointer that a newly `@alloc`'d object will aquire, if the object fits between `current` and `slab_end`.
+ If the object does not fit between `current` and `slab_end`, but is smaller than `slab_size`, we'll `malloc` a new slab,  and add it to `slabs` (reallocating the `slabs` pointer if there's not enough room, as determined by `max_slabs_length`) and then set that thing as the `current` pointer, and provide that to the object.
+ If the object is bigger than `slab_size`, then we `malloc` a pointer of the requested size, and add it to the `custom_slabs` pointer  (also reallocating that pointer if necessary), leaving `current` and `slab_end` unchanged.
+ When a `@no_escape` block ends, we reset `current`, and `slab_end` to their old values, and if `slabs` or `custom_slabs` have grown, we `free` all the pointers that weren't present before, and reset their respective `length`s (but not `max_size`s).

 ________________________

For this PR, I've opted to not rock the boat too much regarding the existing APIs and infrastructure, but I do think that this should be the default way dynamic memory is dealt with in StaticTools because it's very efficient, more user friendly than direct `malloc`/`free`, and quite flexible.

In the future then (or in this PR if we want) we'll need to figure out a good path to dealing with the zoo of different types here, and migrating the test suite, and modifying the documentation to nudge people more towards `MallocSlabBuffer`. 

Regarding types, one potential design question is that Bumper defaults to returning `PtrArray`s from StrideArraysCore.jl, whereas in StaticTools.jl stuff is built around `MallocArray`, which is structurally the same, but has a different name and some different methods like `free`. There's a couple ways forward we could take: 

+ leave it. It's kinda messy with similar but different types floating around everywhere, but maybe fine. 
+ Make `@alloc` produce a `MallocArray` instead of a `PtrArray` when used on a `MallocSlabBuffer`. This could work fine, but I'm not a fan of it being named `MallocArray` if it's being handled by the `MallocSlabBuffer` instead of `malloc` directly 
+ Replace `MallocArray(...)` with `mallocarray(...)::PtrArray` since this change would bring StrideArraysCore.jl into StaticTools.jl anyways, and `PtrArray` has some nice advantages like really good support from LoopVectorization.jl etc. It also has some potential annoyances though, like a shitload of type parameters: 
```julia
julia> buf = MallocSlabBuffer();

julia> @no_escape buf begin
           typeof(@alloc(Int, 10))
       end
PtrArray{Int64, 1, (1,), Tuple{Int64}, Tuple{Nothing}, Tuple{StaticInt{1}}} (alias for StrideArraysCore.AbstractPtrArray{Int64, 1, (1,), Tuple{Int64}, Tuple{Nothing}, Tuple{Static.StaticInt{1}}, Int64})
```