### PR TITLE
Update `stdoutp()`, `stderrp()`, and `stdinp()` for Windows

### DIFF
--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -266,6 +266,22 @@
         attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
+elseif Sys.iswindows()
+    @inline function stdoutp()
+        @assert Int===Int64
+        Base.llvmcall(("""
+        declare i8* @__acrt_iob_func(i32 noundef)
+
+        define i64 @main() #0 {
+        entry:
+          %ptr = call i8* @__acrt_iob_func(i32 noundef 1)
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
+        }
+
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
+        """, "main"), Ptr{FILE}, Tuple{})
+    end
 else
     @inline function stdoutp()
         @assert Int===Int64
@@ -319,6 +335,22 @@ end
         attributes #0 = { alwaysinline nounwind ssp uwtable }
         """, "main"), Ptr{FILE}, Tuple{})
     end
+elseif Sys.iswindows()
+    @inline function stderrp()
+        @assert Int===Int64
+        Base.llvmcall(("""
+        declare i8* @__acrt_iob_func(i32 noundef)
+
+        define i64 @main() #0 {
+        entry:
+          %ptr = call i8* @__acrt_iob_func(i32 noundef 2)
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
+        }
+
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
+        """, "main"), Ptr{FILE}, Tuple{})
+    end
 else
     @inline function stderrp()
         @assert Int===Int64
@@ -361,6 +393,22 @@ end
         define i64 @main() #0 {
         entry:
           %ptr = load i8*, i8** @__stdinp, align 8
+          %jlfp = ptrtoint i8* %ptr to i64
+          ret i64 %jlfp
+        }
+
+        attributes #0 = { alwaysinline nounwind ssp uwtable }
+        """, "main"), Ptr{FILE}, Tuple{})
+    end
+elseif Sys.iswindows()
+    @inline function stdinp()
+        @assert Int===Int64
+        Base.llvmcall(("""
+        declare i8* @__acrt_iob_func(i32 noundef)
+
+        define i64 @main() #0 {
+        entry:
+          %ptr = call i8* @__acrt_iob_func(i32 noundef 0)
           %jlfp = ptrtoint i8* %ptr to i64
           ret i64 %jlfp
         }


### PR DESCRIPTION
On Windows, `stdoutp()`, `stderrp()`, and `stdinp()` don't work:

```julia
julia> @assert Sys.iswindows()
julia> using StaticTools
julia> stdoutp()  # stderrp(), stdinp()
JIT session error: Symbols not found: [ stdout ]
...
```

After this PR:

```julia
julia> stdoutp()
Ptr{StaticTools.FILE} @0x00007ffa2bb8f4f8
julia> stderrp()
Ptr{StaticTools.FILE} @0x00007ffa2bb8f550
julia> stdinp()
Ptr{StaticTools.FILE} @0x00007ffa2bb8f4a0
```
