### PR TITLE
adaptions to Windows: readline(),  added sleep_win()

### DIFF
--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -741,7 +741,7 @@ end
             linelen += 1
             c = getc(fp)
         end
-        offset_fseek = Sys.iswindows() ? 2 : 1
+        offset_fseek = Sys.iswindows() ? 1 : 1
         fseek(fp, (c < 0) - linelen - offset_fseek)
         str = MallocString(undef, linelen + 1) # str[end] == 0x00
         if linelen > 0

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -741,11 +741,12 @@ end
             linelen += 1
             c = getc(fp)
         end
-        fseek(fp, (c < 0) - linelen - 1)
+        offset_fseek = Sys.iswindows() ? 2 : 1
+        fseek(fp, (c < 0) - linelen - offset_fseek)
         str = MallocString(undef, linelen + 1) # str[end] == 0x00
         if linelen > 0
             gets!(str, fp, linelen)
-            fseek(fp, 1) # Advance by 1
+            fseek(fp, offset_fseek) # Advance by the offset
         end
         return str
     end

--- a/src/llvmio.jl
+++ b/src/llvmio.jl
@@ -741,7 +741,7 @@ end
             linelen += 1
             c = getc(fp)
         end
-        offset_fseek = Sys.iswindows() ? 1 : 1
+        offset_fseek = Sys.iswindows() ? 2 : 1
         fseek(fp, (c < 0) - linelen - offset_fseek)
         str = MallocString(undef, linelen + 1) # str[end] == 0x00
         if linelen > 0

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -323,6 +323,21 @@ end
 
 """
 ```julia
+sleep_win(sec::Real)
+```
+sleep function for Windows using Sleep()
+
+## Examples
+```julia
+julia> sleep_win(2.5)
+0
+```
+"""
+@inline sleep_win(secs::Real) = @symbolcall Sleep(round(Int, sec * 1000)) :: Int
+
+
+"""
+```julia
 system(s)
 ```
 Libc `system` function, accessed by direct StaticCompiler-safe `llvmcall`.

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -333,7 +333,7 @@ julia> sleep_win(2.5)
 0
 ```
 """
-@inline sleep_win(secs::Real) = @symbolcall Sleep(round(Int, sec * 1000)) :: Int
+@inline sleep_win(secs::Real) = @symbolcall Sleep(round(Int, sec * 1000)::Int) :: Int
 
 
 """

--- a/src/llvmlibc.jl
+++ b/src/llvmlibc.jl
@@ -333,7 +333,10 @@ julia> sleep_win(2.5)
 0
 ```
 """
-@inline sleep_win(secs::Real) = @symbolcall Sleep(round(Int, sec * 1000)::Int) :: Int
+function sleep_win(secs::Real)
+    millisecs = round(Int, secs * 1000)
+    @symbolcall Sleep(millisecs :: Int) :: Int
+end
 
 
 """


### PR DESCRIPTION
readline(): offset for fseek must be 2
sleep_win(): usleep does not work. used function Sleep() for Windows